### PR TITLE
Fix DST handling in GtfsIngester.parse_gtfs_time

### DIFF
--- a/eflips/ingest/gtfs.py
+++ b/eflips/ingest/gtfs.py
@@ -13,7 +13,7 @@ from eflips.ingest.util import get_altitude, geometry_has_z
 import uuid
 import warnings
 from datetime import date as date_type
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from eflips.model import (
     Station,
     Line,
@@ -278,15 +278,68 @@ class GtfsIngester(AbstractIngester):
         """
         Parse GTFS time format (HH:MM:SS) which can exceed 24 hours.
 
-        :param time_str: Time string in HH:MM:SS format
-        :param base_date: Base datetime to add the time to (should have timezone info)
-        :return: Datetime object representing the parsed time
+        Per the GTFS Schedule reference (Field Types - Time):
+
+            The time is measured from "noon minus 12h" of the service day
+            (effectively midnight except for days on which daylight savings
+            time changes occur).
+
+        https://gtfs.org/documentation/schedule/reference/#field-types
+
+        We follow this definition literally rather than the more common
+        shortcut of adding the parsed HH:MM:SS to local midnight: on DST
+        transition days, "noon minus 12h" differs from local midnight by
+        exactly the DST offset, and using local midnight produces non-
+        monotonic UTC instants for stops bracketing the DST gap (which
+        then trip the Trip.arrival_time > Trip.departure_time CHECK
+        constraint at insert time).
+
+        :param time_str: Time string in HH:MM:SS format. May exceed 24:00:00
+                         for trips that continue past the end of the service
+                         day.
+        :param base_date: A datetime whose date components identify the
+                          service day. If timezone-aware, the result is
+                          returned in the same timezone; if naive, the GTFS
+                          delta is added directly (no DST to consider) and
+                          a warning is logged.
+        :return: Datetime object representing the parsed time.
         """
         parts = time_str.split(":")
         hours = int(parts[0])
         minutes = int(parts[1])
         seconds = int(parts[2])
-        return base_date + timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        delta = timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+        if base_date.tzinfo is None:
+            # No timezone information - fall back to wall-clock addition. The
+            # callers in this module always pass a tz-aware base_date, so a
+            # naive value here is a bug upstream that would produce silently
+            # wrong results on DST transition days. Warn loudly so it gets
+            # noticed.
+            logging.getLogger(__name__).warning(
+                "parse_gtfs_time called with naive base_date %r; DST handling "
+                "is disabled and results will be incorrect on DST transition "
+                "days. Pass a timezone-aware base_date.",
+                base_date,
+            )
+            return base_date + delta
+
+        # Step 1: locate noon (local) on the service day. Noon always exists
+        # exactly once: DST transitions happen in the early hours, never at
+        # midday.
+        noon_local = base_date.replace(hour=12, minute=0, second=0, microsecond=0)
+
+        # Step 2: subtract 12 hours of REAL elapsed time to obtain the
+        # service-day anchor. We move through UTC for the subtraction -
+        # subtracting a timedelta directly from an aware datetime would
+        # re-derive the offset on the new wall clock, which is exactly the
+        # class of mistake this function is being rewritten to avoid.
+        noon_utc = noon_local.astimezone(timezone.utc)
+        anchor_utc = noon_utc - timedelta(hours=12)
+
+        # Step 3: add the GTFS offset as real elapsed time, then project the
+        # result back into the original timezone.
+        return (anchor_utc + delta).astimezone(base_date.tzinfo)
 
     def parent_station_id_exists(self, parent_station_id: Any) -> bool:
         """Check is a given parent_station_id value is "filled" (not null/NA/empty)"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "1.4.3"
+version = "1.4.4"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -1,4 +1,6 @@
-from datetime import datetime, timedelta
+import logging
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 import os.path
 from pathlib import Path
 from uuid import UUID
@@ -342,3 +344,95 @@ class TestGtfsIngester(BaseIngester):
         )
         assert success
         assert isinstance(result, UUID)
+
+
+class TestParseGtfsTime:
+    """Unit tests for ``GtfsIngester.parse_gtfs_time``.
+
+    These tests pin the spec-literal "noon minus 12h" interpretation of GTFS
+    times, which is what protects DST transition days from producing
+    non-monotonic UTC instants. The function is a ``@staticmethod`` so the
+    tests do not need any database or ingester fixtures.
+
+    Each assertion compares ``result.astimezone(timezone.utc)`` rather than
+    the wall-clock representation. Comparing two aware datetimes that share a
+    ``tzinfo`` instance falls into Python's same-tzinfo fast path, which
+    operates on naive wall-clock components and ignores per-instance offsets
+    -- exactly the trap that hid the original bug from the in-memory
+    ``sorted(...)`` ordering check.
+    """
+
+    BERLIN = ZoneInfo("Europe/Berlin")
+
+    def test_normal_day(self) -> None:
+        """On a non-DST day, GTFS HH:MM:SS should match local wall clock."""
+        base_date = datetime(2026, 3, 28, tzinfo=self.BERLIN)
+        result = GtfsIngester.parse_gtfs_time("14:30:00", base_date)
+
+        assert result.astimezone(timezone.utc) == datetime(2026, 3, 28, 13, 30, tzinfo=timezone.utc)
+
+    def test_spring_forward_day_brackets_dst_gap(self) -> None:
+        """Regression test for the original bug.
+
+        On 2026-03-29 in Europe/Berlin the local clock jumps from 02:00 CET
+        directly to 03:00 CEST. A trip with stops at "2:55:00" and "3:19:00"
+        previously produced an arrival before the departure in UTC, tripping
+        the Trip CHECK constraint. After the fix, both times must be
+        monotonic in UTC and equal the spec's "noon minus 12h" anchor +
+        offset.
+        """
+        base_date = datetime(2026, 3, 29, tzinfo=self.BERLIN)
+
+        early = GtfsIngester.parse_gtfs_time("2:55:00", base_date)
+        late = GtfsIngester.parse_gtfs_time("3:19:00", base_date)
+
+        # Spec: noon = 12:00 CEST = 10:00 UTC, anchor = 22:00 UTC the day
+        # before. early = anchor + 2h55m = 00:55 UTC, late = anchor + 3h19m
+        # = 01:19 UTC.
+        assert early.astimezone(timezone.utc) == datetime(2026, 3, 29, 0, 55, tzinfo=timezone.utc)
+        assert late.astimezone(timezone.utc) == datetime(2026, 3, 29, 1, 19, tzinfo=timezone.utc)
+
+        # The actual constraint that the SQL CHECK enforces.
+        assert early.astimezone(timezone.utc) < late.astimezone(timezone.utc)
+
+    def test_fall_back_day(self) -> None:
+        """On 2025-10-26 in Europe/Berlin the clock falls back at 03:00 CEST.
+
+        Noon is 12:00 CET = 11:00 UTC, so the anchor is 23:00 UTC on
+        2025-10-25. "12:00:00" must still land at noon local; "01:00:00"
+        must land at the *first* occurrence of 02:00 local (CEST), which is
+        00:00 UTC on the service day.
+        """
+        base_date = datetime(2025, 10, 26, tzinfo=self.BERLIN)
+
+        noon = GtfsIngester.parse_gtfs_time("12:00:00", base_date)
+        one_am = GtfsIngester.parse_gtfs_time("01:00:00", base_date)
+
+        assert noon.astimezone(timezone.utc) == datetime(2025, 10, 26, 11, 0, tzinfo=timezone.utc)
+        assert one_am.astimezone(timezone.utc) == datetime(2025, 10, 26, 0, 0, tzinfo=timezone.utc)
+
+    def test_overflow_past_midnight(self) -> None:
+        """GTFS times can exceed 24:00:00 for trips that span midnight."""
+        base_date = datetime(2026, 3, 28, tzinfo=self.BERLIN)
+
+        result = GtfsIngester.parse_gtfs_time("25:35:00", base_date)
+
+        # 2026-03-28 is a normal day, anchor = local midnight = 23:00 UTC
+        # the previous day. + 25h35m = 00:35 UTC on 2026-03-29.
+        assert result.astimezone(timezone.utc) == datetime(2026, 3, 29, 0, 35, tzinfo=timezone.utc)
+
+    def test_naive_base_date_falls_back_and_warns(self, caplog) -> None:
+        """A naive ``base_date`` is a caller bug; we still produce a result
+        via direct timedelta addition, but we log a WARNING so it gets
+        noticed."""
+        naive_base = datetime(2026, 3, 28)
+
+        with caplog.at_level(logging.WARNING, logger="eflips.ingest.gtfs"):
+            result = GtfsIngester.parse_gtfs_time("14:30:00", naive_base)
+
+        assert result == datetime(2026, 3, 28, 14, 30)
+        assert result.tzinfo is None
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING for naive base_date"
+        assert any("naive base_date" in r.getMessage() for r in warnings)


### PR DESCRIPTION
Importing a GTFS feed whose service window contains a DST spring-forward day in a DST-observing timezone failed with a Trip CHECK constraint: arrival_time appeared earlier than departure_time for trips whose stops bracketed the DST gap (e.g. 02:55 -> 03:19 on 2026-03-29 in Europe/Berlin).

Root cause: parse_gtfs_time added a timedelta to a tz-aware local-midnight base_date. Python's aware-datetime arithmetic operates on wall-clock components, so a phantom 02:55 wall-clock in the DST gap got the pre-transition (CET) offset and a real 03:19 wall-clock got the post-transition (CEST) offset. The two times were monotonic in local wall clock but non-monotonic in UTC, and SQLAlchemy serialised them to UTC before SQLite's CHECK fired. The in-memory ordering check missed the inversion because Python's same-tzinfo fast path compares aware datetimes on naive wall-clock components.

Rewrite parse_gtfs_time to follow the GTFS Schedule reference literally:

    "The time is measured from 'noon minus 12h' of the service day
    (effectively midnight except for days on which daylight savings
    time changes occur)."
    -- https://gtfs.org/documentation/schedule/reference/#field-types

Take noon (local) on the service day -- always unambiguous, since DST transitions never happen at midday -- convert to UTC, subtract 12h of real elapsed time to obtain the service-day anchor, then add the parsed HH:MM:SS as a real-time offset and project back into the original tz. The intermediate variables (noon_local, noon_utc, anchor_utc) make each sentence of the spec directly readable in the code.

A naive base_date now logs a WARNING and falls back to wall-clock addition. The two real call sites in this module always pass tz-aware base_dates, so a naive value is a caller bug that would silently produce wrong results on DST days.

Adds five regression unit tests in TestParseGtfsTime covering: a normal day, a spring-forward day with stops bracketing the DST gap (the original repro), a fall-back day, an overflow >24h time, and the naive-base_date fallback (asserting both the result and the warning).