### PR TITLE
Fix KeyError when GTFS stops.txt has no parent_station column

### DIFF
--- a/eflips/ingest/gtfs.py
+++ b/eflips/ingest/gtfs.py
@@ -151,6 +151,10 @@ class GtfsIngester(AbstractIngester):
         # Read the GTFS feed
         feed = gk.read_feed(gtfs_zip_file, dist_units="m")
 
+        # Ensure stops has a parent_station column (optional in GTFS spec, but required by gtfs_kit filtering)
+        if feed.stops is not None and "parent_station" not in feed.stops.columns:
+            feed.stops["parent_station"] = pd.NA
+
         # Handle multi-agency feeds
         agency_filter_result = self.filter_feed_by_agency(feed, agency_name)
         if isinstance(agency_filter_result, tuple):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "1.4.4"
+version = "1.4.5"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -144,14 +144,28 @@ class TestGtfsIngester(BaseIngester):
         validity = ingester.get_feed_validity_period(feed)
         start_date = datetime.strptime(validity[0], "%Y%m%d").date()
 
-        # Note: sample-feed-1 has no parent_station column, so we use bus_only=False
-        # to avoid gtfs_kit filtering issues (all routes are buses anyway)
         success, result = ingester.prepare(
             progress_callback=None,
             gtfs_zip_file=sample_feed_1,
             start_date=start_date.isoformat(),
             duration="DAY",
             bus_only=False,
+        )
+        assert success
+        assert isinstance(result, UUID)
+
+    def test_prepare_sample_feed_1_bus_only(self, ingester, sample_feed_1) -> None:
+        """Test that sample-feed-1.zip works with bus_only=True despite missing parent_station column."""
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        validity = ingester.get_feed_validity_period(feed)
+        start_date = datetime.strptime(validity[0], "%Y%m%d").date()
+
+        success, result = ingester.prepare(
+            progress_callback=None,
+            gtfs_zip_file=sample_feed_1,
+            start_date=start_date.isoformat(),
+            duration="DAY",
+            bus_only=True,
         )
         assert success
         assert isinstance(result, UUID)
@@ -182,7 +196,6 @@ class TestGtfsIngester(BaseIngester):
         validity = ingester.get_feed_validity_period(feed)
         start_date = datetime.strptime(validity[0], "%Y%m%d").date()
 
-        # Note: sample-feed-1 has no parent_station column, so we use bus_only=False
         success, uuid = ingester.prepare(
             progress_callback=None,
             gtfs_zip_file=sample_feed_1,


### PR DESCRIPTION
## Summary
- GTFS feeds where `stops.txt` lacks a `parent_station` column (valid per spec) caused a `KeyError` in gtfs_kit's `restrict_to_routes`/`restrict_to_agencies`
- Added an empty `parent_station` column after reading the feed when it is missing
- Added test case using `sample-feed-1.zip` with `bus_only=True` to cover this scenario

## Test plan
- [x] New test `test_prepare_sample_feed_1_bus_only` passes
- [x] Existing sample-feed-1 and SWU tests still pass
- [x] black and mypy (strict) pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)