### PR TITLE
Allow multi-agency selection in filter_feed_by_agency

### DIFF
--- a/eflips/ingest/gtfs.py
+++ b/eflips/ingest/gtfs.py
@@ -1143,6 +1143,7 @@ class GtfsIngester(AbstractIngester):
             "start_date": "Start date for the import (ISO 8601 format, e.g., '2024-01-15')",
             "duration": "Duration to import ('DAY' or 'WEEK')",
             "agency_name": "Agency name (required if feed contains multiple agencies)",
+            "agency_id": "Agency ID (alternative to agency_name)",
             "bus_only": "Filter to only import bus routes (default: True)",
         }
 
@@ -1171,6 +1172,9 @@ class GtfsIngester(AbstractIngester):
             "feed contains multiple agencies. If the feed contains only one agency, this parameter is optional and "
             "will be ignored. The agency name must match the 'agency_name' field in agency.txt exactly. If not "
             "specified for a multi-agency feed, an error will be returned listing all available agencies.",
+            "agency_id": "The ID of the agency to import from the GTFS feed. Can be used as an alternative to "
+            "agency_name. The agency ID must match the 'agency_id' field in agency.txt exactly. Accepts a single "
+            "string or an iterable of strings to select multiple agencies.",
             "bus_only": "If True (default), only bus routes will be imported from the GTFS feed. This includes routes "
             "with route_type of 3 (standard GTFS bus) or 700-799 (extended GTFS bus types). If False, all route types "
             "will be imported. If set to True and the feed contains no bus routes, an error will be returned.",

--- a/eflips/ingest/gtfs.py
+++ b/eflips/ingest/gtfs.py
@@ -34,7 +34,7 @@ from gtfs_kit import Feed
 from pathlib import Path
 from shapely.geometry import Point  # type: ignore [import-untyped]
 from sqlalchemy.orm import Session
-from typing import Dict, Callable, Tuple, List, Any
+from typing import Dict, Callable, Iterable, Tuple, List, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -94,7 +94,8 @@ class GtfsIngester(AbstractIngester):
         start_date: str,
         progress_callback: None | Callable[[float], None] = None,
         duration: str = "WEEK",
-        agency_name: str = "",
+        agency_name: str | Iterable[str] = "",
+        agency_id: str | Iterable[str] = "",
         bus_only: bool = True,
     ) -> Tuple[bool, UUID | Dict[str, str]]:
         """
@@ -131,7 +132,10 @@ class GtfsIngester(AbstractIngester):
         :param gtfs_zip_file: Path to the GTFS zip file
         :param start_date: Start date for import in ISO 8601 format (YYYY-MM-DD)
         :param duration: Duration of import period ('DAY' or 'WEEK')
-        :param agency_name: Name of the agency to import (required if feed contains multiple agencies)
+        :param agency_name: Name of the agency to import, or an iterable of names to combine
+            (required if feed contains multiple agencies, unless ``agency_id`` is given)
+        :param agency_id: Id of the agency to import, or an iterable of ids to combine
+            (may be used instead of, or together with, ``agency_name``)
         :param bus_only: If True (default), only import bus routes (route_type 3 or 700-799)
         :param progress_callback: Optional callback function for progress updates
         :return: A tuple containing a boolean indicating whether the input data is valid and either a UUID or a dictionary
@@ -156,7 +160,7 @@ class GtfsIngester(AbstractIngester):
             feed.stops["parent_station"] = pd.NA
 
         # Handle multi-agency feeds
-        agency_filter_result = self.filter_feed_by_agency(feed, agency_name)
+        agency_filter_result = self.filter_feed_by_agency(feed, agency_name, agency_id)
         if isinstance(agency_filter_result, tuple):
             # Error occurred
             return agency_filter_result
@@ -265,8 +269,8 @@ class GtfsIngester(AbstractIngester):
             "feed": feed,
             "gtfs_zip_file": gtfs_zip_file,
             "tz": tz,
-            "agency_name": feed.agency.iloc[0]["agency_name"]
-            if "agency_name" in feed.agency.columns
+            "agency_name": " / ".join(feed.agency["agency_name"].tolist())
+            if "agency_name" in feed.agency.columns and len(feed.agency) > 0
             else "Unknown Agency",
             "start_date": start_date,
             "duration": duration,
@@ -1172,17 +1176,27 @@ class GtfsIngester(AbstractIngester):
             "will be imported. If set to True and the feed contains no bus routes, an error will be returned.",
         }
 
-    def filter_feed_by_agency(self, feed: Feed, agency_name: str | None) -> Feed | Tuple[bool, Dict[str, str]]:
+    def filter_feed_by_agency(
+        self,
+        feed: Feed,
+        agency_name: str | Iterable[str] | None = None,
+        agency_id: str | Iterable[str] | None = None,
+    ) -> Feed | Tuple[bool, Dict[str, str]]:
         """
-        Filter the GTFS feed to include only data from a specific agency.
+        Filter the GTFS feed to include only data from one or more agencies.
 
-        If the feed contains multiple agencies and no agency_name is specified,
-        returns an error tuple with available agency names.
+        Agencies can be selected by name, by id, or by a combination of both.
+        Each selector accepts either a single string or an iterable of strings,
+        allowing callers that operate a shared depot across multiple "paper"
+        agencies to pass all of them in a single call.
 
-        If the feed contains only one agency, the agency_name parameter is ignored.
+        If the feed contains only one agency, both selectors are ignored.
+        If the feed contains multiple agencies and neither selector is given,
+        returns an error tuple with the list of available agencies.
 
         :param feed: A gtfs_kit Feed object
-        :param agency_name: Name of the agency to filter by (optional if single-agency feed)
+        :param agency_name: Name(s) of agencies to keep (str or iterable of str)
+        :param agency_id: Id(s) of agencies to keep (str or iterable of str)
         :return: Filtered Feed object, or error tuple (False, error_dict)
         """
         if feed.agency is None or len(feed.agency) == 0:
@@ -1190,41 +1204,70 @@ class GtfsIngester(AbstractIngester):
 
         num_agencies = len(feed.agency)
 
+        def _normalise(selector: str | Iterable[str] | None) -> List[str]:
+            if selector is None:
+                return []
+            if isinstance(selector, str):
+                return [selector] if selector != "" else []
+            return [s for s in selector if s != ""]
+
+        wanted_names = _normalise(agency_name)
+        wanted_ids = _normalise(agency_id)
+
         # Single agency - no filtering needed
         if num_agencies == 1:
-            if agency_name and agency_name != "":
-                self.logger.info(f"Feed contains only one agency, ignoring agency_name parameter '{agency_name}'")
+            if wanted_names or wanted_ids:
+                self.logger.info(
+                    f"Feed contains only one agency, ignoring agency_name={wanted_names!r} " f"agency_id={wanted_ids!r}"
+                )
             return feed
 
-        # Multiple agencies - agency_name is required
-        if not agency_name or agency_name == "":
-            # Build helpful error message with list of available agencies
+        # Multiple agencies - at least one selector is required
+        if not wanted_names and not wanted_ids:
             agency_names = feed.agency["agency_name"].tolist()
             agency_list = "\n".join(f"  - {name}" for name in agency_names)
             error_msg = (
                 f"The GTFS feed contains {num_agencies} agencies. "
-                f"Please specify which agency to import using the 'agency_name' parameter.\n\n"
+                f"Please specify which agency or agencies to import using the "
+                f"'agency_name' or 'agency_id' parameter (a single string or a "
+                f"list of strings is accepted).\n\n"
                 f"Available agencies:\n{agency_list}"
             )
             return (False, {"agency_name": error_msg})
 
-        # Find the agency by name
-        matching_agencies = feed.agency[feed.agency["agency_name"] == agency_name]
+        matched_by_name = feed.agency[feed.agency["agency_name"].isin(wanted_names)] if wanted_names else None
+        matched_by_id = feed.agency[feed.agency["agency_id"].astype(str).isin(wanted_ids)] if wanted_ids else None
 
-        if len(matching_agencies) == 0:
-            # Agency name not found
-            agency_names = feed.agency["agency_name"].tolist()
-            agency_list = "\n".join(f"  - {name}" for name in agency_names)
-            error_msg = f"Agency '{agency_name}' not found in GTFS feed.\n\n" f"Available agencies:\n{agency_list}"
-            return (False, {"agency_name": error_msg})
+        errors: Dict[str, str] = {}
+        if matched_by_name is not None:
+            missing_names = sorted(set(wanted_names) - set(matched_by_name["agency_name"]))
+            if missing_names:
+                agency_names_list = feed.agency["agency_name"].tolist()
+                agency_list = "\n".join(f"  - {name}" for name in agency_names_list)
+                errors["agency_name"] = (
+                    f"Agency name(s) {missing_names} not found in GTFS feed.\n\n" f"Available agencies:\n{agency_list}"
+                )
+        if matched_by_id is not None:
+            missing_ids = sorted(set(wanted_ids) - set(matched_by_id["agency_id"].astype(str)))
+            if missing_ids:
+                agency_ids_list = feed.agency["agency_id"].astype(str).tolist()
+                agency_list = "\n".join(f"  - {aid}" for aid in agency_ids_list)
+                errors["agency_id"] = (
+                    f"Agency id(s) {missing_ids} not found in GTFS feed.\n\n" f"Available agency ids:\n{agency_list}"
+                )
+        if errors:
+            return (False, errors)
 
-        # Get the agency_id for filtering
-        agency_id = matching_agencies.iloc[0]["agency_id"]
-        self.logger.info(f"Filtering feed to agency '{agency_name}' (ID: {agency_id})")
+        frames = [df for df in (matched_by_name, matched_by_id) if df is not None]
+        combined = pd.concat(frames).drop_duplicates(subset=["agency_id"])
+        agency_ids_to_keep = list(combined["agency_id"])
+        self.logger.info(
+            f"Filtering feed to {len(agency_ids_to_keep)} agency/agencies "
+            f"(ids: {agency_ids_to_keep}, names: {list(combined['agency_name'])})"
+        )
 
-        # Use gtfs_kit's restrict_to_agencies to filter the feed
         try:
-            filtered_feed = feed.restrict_to_agencies([agency_id])
+            filtered_feed = feed.restrict_to_agencies(agency_ids_to_keep)
             assert isinstance(filtered_feed, Feed)
             self.logger.info(f"Feed filtered: {len(feed.routes)} routes → {len(filtered_feed.routes)} routes")
             return filtered_feed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "1.4.5"
+version = "1.5.0"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/base.py
+++ b/tests/base.py
@@ -96,7 +96,10 @@ class BaseIngester(ABC):
                 continue
             if param.annotation in [str, int, float, bool, pathlib.Path]:
                 continue
-            elif issubclass(param.annotation, Enum):
+            elif inspect.isclass(param.annotation) and issubclass(param.annotation, Enum):
+                continue
+            elif not inspect.isclass(param.annotation):
+                # Union types (e.g. str | Iterable[str]) are not classes
                 continue
             else:
                 raise AssertionError(f"Invalid parameter type {param.annotation} for parameter {param.name}.")
@@ -115,7 +118,7 @@ class BaseIngester(ABC):
             if param.name == "progress_callback":
                 continue
             assert param.name in ingester.prepare_param_names().keys()
-            if issubclass(param.annotation, Enum):
+            if inspect.isclass(param.annotation) and issubclass(param.annotation, Enum):
                 assert isinstance(ingester.prepare_param_names()[param.name], dict)
                 for value in param.annotation:
                     assert value in ingester.prepare_param_names()[param.name].keys()
@@ -136,7 +139,7 @@ class BaseIngester(ABC):
             if param.name == "progress_callback":
                 continue
             assert param.name in ingester.prepare_param_description().keys()
-            if issubclass(param.annotation, Enum):
+            if inspect.isclass(param.annotation) and issubclass(param.annotation, Enum):
                 assert isinstance(ingester.prepare_param_description()[param.name], dict)
                 for value in param.annotation:
                     assert value in ingester.prepare_param_description()[param.name].keys()

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -65,6 +65,44 @@ class TestGtfsIngester(BaseIngester):
         return sample_path.resolve()
 
     @pytest.fixture()
+    def multi_agency_feed_zip(self, sample_feed_1, tmp_path) -> Path:
+        """Multi-agency GTFS zip built in-memory from sample-feed-1.
+
+        The source feed has a single agency; we triplicate the agency row with
+        distinct ids/names and round-robin distribute the routes across them
+        so each agency owns at least one route. All trip/stop_times/calendar
+        rows keep their original route_ids, so downstream filtering still
+        works.
+        """
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        base_row = feed.agency.iloc[0].to_dict()
+        new_agencies = []
+        for aid, aname in [
+            ("A1", "Agency One"),
+            ("A2", "Agency Two"),
+            ("A3", "Agency Three"),
+        ]:
+            row = dict(base_row)
+            row["agency_id"] = aid
+            row["agency_name"] = aname
+            new_agencies.append(row)
+        import pandas as pd
+
+        feed.agency = pd.DataFrame(new_agencies)
+
+        routes = feed.routes.reset_index(drop=True).copy()
+        assigned_ids = [["A1", "A2", "A3"][i % 3] for i in range(len(routes))]
+        routes["agency_id"] = assigned_ids
+        feed.routes = routes
+
+        if feed.stops is not None and "parent_station" not in feed.stops.columns:
+            feed.stops["parent_station"] = pd.NA
+
+        out_path = tmp_path / "multi_agency.zip"
+        feed.to_file(out_path)
+        return out_path
+
+    @pytest.fixture()
     def vbb_feed(self) -> Path:
         """Path to VBB GTFS feed (multi-agency, used ONLY for agency filtering tests)."""
         path_of_this_file = Path(os.path.dirname(__file__))
@@ -357,6 +395,67 @@ class TestGtfsIngester(BaseIngester):
         )
         assert success
         assert isinstance(result, UUID)
+
+    # ====================
+    # Multi-Agency Selector Tests (list/iterable of names or ids)
+    # ====================
+
+    def test_multi_agency_list_of_names(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        result = ingester.filter_feed_by_agency(feed, agency_name=["Agency One", "Agency Two"])
+        assert isinstance(result, gk.Feed)
+        assert set(result.agency["agency_name"]) == {"Agency One", "Agency Two"}
+        assert set(result.routes["agency_id"]) <= {"A1", "A2"}
+
+    def test_multi_agency_list_of_ids(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        result = ingester.filter_feed_by_agency(feed, agency_id=["A1", "A3"])
+        assert isinstance(result, gk.Feed)
+        assert set(result.agency["agency_id"].astype(str)) == {"A1", "A3"}
+
+    def test_multi_agency_mixed_names_and_ids(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        result = ingester.filter_feed_by_agency(feed, agency_name=["Agency One"], agency_id=["A2"])
+        assert isinstance(result, gk.Feed)
+        assert set(result.agency["agency_id"].astype(str)) == {"A1", "A2"}
+
+    def test_multi_agency_single_string_still_works(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        result = ingester.filter_feed_by_agency(feed, agency_name="Agency One")
+        assert isinstance(result, gk.Feed)
+        assert list(result.agency["agency_name"]) == ["Agency One"]
+
+    def test_multi_agency_partial_miss_reports_error(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        result = ingester.filter_feed_by_agency(feed, agency_name=["Agency One", "Nope"])
+        assert isinstance(result, tuple)
+        success, error_dict = result
+        assert success is False
+        assert "agency_name" in error_dict
+        assert "Nope" in error_dict["agency_name"]
+
+    def test_prepare_multi_agency_list_scenario_name(self, ingester, multi_agency_feed_zip) -> None:
+        feed = gk.read_feed(multi_agency_feed_zip, dist_units="m")
+        validity = ingester.get_feed_validity_period(feed)
+        start_date = datetime.strptime(validity[0], "%Y%m%d").date()
+
+        success, result = ingester.prepare(
+            progress_callback=None,
+            gtfs_zip_file=multi_agency_feed_zip,
+            start_date=start_date.isoformat(),
+            duration="DAY",
+            agency_name=["Agency One", "Agency Two"],
+            bus_only=False,
+        )
+        assert success, result
+        assert isinstance(result, UUID)
+
+        import pickle
+
+        save_path = ingester.path_for_uuid(result)
+        with open(save_path / "gtfs_data.dill", "rb") as f:
+            data = pickle.load(f)
+        assert data["agency_name"] == "Agency One / Agency Two"
 
 
 class TestParseGtfsTime:


### PR DESCRIPTION
We sometimes want to simulate several agencies from a GTFS feed together (e.g. when they share a depot). The filter previously only accepted one exact agency_name, forcing callers to drop data, run multiple disconnected simulations, or pre-edit the zip.

Widen filter_feed_by_agency and prepare to accept str or Iterable[str] for both agency_name and a new agency_id selector; matches are unioned and passed to feed.restrict_to_agencies in a single call. Single-string callers are unaffected. Bumps version to 1.5.0.