### PR TITLE
Add route_ids selector to GtfsIngester.prepare

### DIFF
--- a/eflips/ingest/gtfs.py
+++ b/eflips/ingest/gtfs.py
@@ -1,19 +1,21 @@
-import gtfs_kit as gk  # type: ignore [import-untyped]
 import logging
 import os
-import pandas as pd
 import pathlib as pl
 import pickle
 import sys
 import time
-
-from shapely import LineString  # type: ignore [import-untyped]
-
-from eflips.ingest.util import get_altitude, geometry_has_z
 import uuid
 import warnings
 from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Callable, Iterable, Tuple, List, Any
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+import gtfs_kit as gk  # type: ignore [import-untyped]
+import pandas as pd
 from eflips.model import (
     Station,
     Line,
@@ -28,17 +30,14 @@ from eflips.model import (
     Base,
 )
 from eflips.model import create_engine
-from enum import Enum
 from geoalchemy2.shape import from_shape
 from gtfs_kit import Feed
-from pathlib import Path
+from shapely import LineString  # type: ignore [import-untyped]
 from shapely.geometry import Point  # type: ignore [import-untyped]
 from sqlalchemy.orm import Session
-from typing import Dict, Callable, Iterable, Tuple, List, Any
-from uuid import UUID, uuid4
-from zoneinfo import ZoneInfo
 
 from eflips.ingest.base import AbstractIngester
+from eflips.ingest.util import get_altitude, geometry_has_z
 
 
 class GtfsIngester(AbstractIngester):
@@ -97,6 +96,7 @@ class GtfsIngester(AbstractIngester):
         agency_name: str | Iterable[str] = "",
         agency_id: str | Iterable[str] = "",
         bus_only: bool = True,
+        route_ids: str | Iterable[str] | None = None,
     ) -> Tuple[bool, UUID | Dict[str, str]]:
         """
         Prepare and validate the input data for ingestion.
@@ -158,6 +158,14 @@ class GtfsIngester(AbstractIngester):
         # Ensure stops has a parent_station column (optional in GTFS spec, but required by gtfs_kit filtering)
         if feed.stops is not None and "parent_station" not in feed.stops.columns:
             feed.stops["parent_station"] = pd.NA
+
+        # Filter by route_ids if provided
+        if route_ids:
+            route_id_filter_result = self.filter_feed_by_route_ids(feed, route_ids)
+            if isinstance(route_id_filter_result, tuple):
+                # Error occurred
+                return route_id_filter_result
+            feed = route_id_filter_result
 
         # Handle multi-agency feeds
         agency_filter_result = self.filter_feed_by_agency(feed, agency_name, agency_id)
@@ -1145,6 +1153,7 @@ class GtfsIngester(AbstractIngester):
             "agency_name": "Agency name (required if feed contains multiple agencies)",
             "agency_id": "Agency ID (alternative to agency_name)",
             "bus_only": "Filter to only import bus routes (default: True)",
+            "route_ids": "Route id(s) to restrict the import to (optional)",
         }
 
     @classmethod
@@ -1178,7 +1187,25 @@ class GtfsIngester(AbstractIngester):
             "bus_only": "If True (default), only bus routes will be imported from the GTFS feed. This includes routes "
             "with route_type of 3 (standard GTFS bus) or 700-799 (extended GTFS bus types). If False, all route types "
             "will be imported. If set to True and the feed contains no bus routes, an error will be returned.",
+            "route_ids": "Optional route id(s) to restrict the import to. Accepts a single string or an iterable of "
+            "strings matching the 'route_id' field in routes.txt. When provided, the feed is filtered to those "
+            "routes (and their dependent trips, stops, shapes, etc.) before any agency or bus-only filtering. "
+            "If any supplied route id is not present in the feed, an error listing the available route ids is "
+            "returned. If omitted or empty, no route-id filtering is applied.",
         }
+
+    @staticmethod
+    def _coerce_str_list(value: str | Iterable[str] | None) -> List[str]:
+        """Normalise a scalar/iterable/None into a list of non-empty strings.
+
+        ``None`` / ``""`` → ``[]``; a single string → ``[s]``; any iterable of
+        strings → a list with empty entries dropped.
+        """
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            return [value]
+        return [str(v) for v in value if v not in (None, "")]
 
     def filter_feed_by_agency(
         self,
@@ -1208,15 +1235,8 @@ class GtfsIngester(AbstractIngester):
 
         num_agencies = len(feed.agency)
 
-        def _normalise(selector: str | Iterable[str] | None) -> List[str]:
-            if selector is None:
-                return []
-            if isinstance(selector, str):
-                return [selector] if selector != "" else []
-            return [s for s in selector if s != ""]
-
-        wanted_names = _normalise(agency_name)
-        wanted_ids = _normalise(agency_id)
+        wanted_names = self._coerce_str_list(agency_name)
+        wanted_ids = self._coerce_str_list(agency_id)
 
         # Single agency - no filtering needed
         if num_agencies == 1:
@@ -1323,6 +1343,57 @@ class GtfsIngester(AbstractIngester):
             return filtered_feed
         except Exception as e:
             return (False, {"route_type_filter": f"Failed to filter feed by route type: {str(e)}"})
+
+    def filter_feed_by_route_ids(
+        self,
+        feed: Feed,
+        route_ids: str | Iterable[str] | None,
+    ) -> Feed | Tuple[bool, Dict[str, str]]:
+        """
+        Filter the GTFS feed to only the given routes and their dependent data.
+
+        Uses ``Feed.restrict_to_routes`` from gtfs_kit, which cascades the
+        restriction through trips, stop_times, stops (including parent stations),
+        calendar, calendar_dates, shapes, frequencies, and transfers — so the
+        returned feed contains no orphaned ancillary data.
+
+        Empty / None ``route_ids`` is treated as a no-op and returns the feed
+        unchanged, symmetric with ``bus_only=False`` in ``filter_feed_by_route_type``.
+
+        :param feed: A gtfs_kit Feed object
+        :param route_ids: Route id(s) to keep. Accepts a single string, an iterable
+            of strings, or None/"" / [] for "no filter".
+        :return: Filtered Feed object, or error tuple (False, error_dict)
+        """
+        wanted_ids = self._coerce_str_list(route_ids)
+        if not wanted_ids:
+            self.logger.info("No route_ids provided: skipping route-id filter")
+            return feed
+
+        if feed.routes is None or len(feed.routes) == 0:
+            return (False, {"routes": "No routes found in GTFS feed"})
+
+        feed_route_ids = set(feed.routes["route_id"].astype(str))
+        missing = sorted(set(wanted_ids) - feed_route_ids)
+        if missing:
+            available = "\n".join(f"  - {rid}" for rid in sorted(feed_route_ids))
+            return (
+                False,
+                {
+                    "route_ids": (
+                        f"Route id(s) {missing} not found in GTFS feed.\n\n" f"Available route ids:\n{available}"
+                    )
+                },
+            )
+
+        self.logger.info(f"Filtering feed to {len(wanted_ids)} route id(s)")
+        try:
+            filtered_feed = feed.restrict_to_routes(wanted_ids)
+            assert isinstance(filtered_feed, Feed)
+            self.logger.info(f"Feed filtered: {len(feed.routes)} routes → {len(filtered_feed.routes)} routes")
+            return filtered_feed
+        except Exception as e:
+            return (False, {"route_ids_filter": f"Failed to filter feed by route ids: {str(e)}"})
 
     def build_route_geometries(self, feed: Feed) -> Dict[str, Any] | None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "1.5.0"
+version = "1.6.0"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -1,16 +1,15 @@
 import logging
-from datetime import datetime, timedelta, timezone
-from zoneinfo import ZoneInfo
 import os.path
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
+import gtfs_kit as gk
 import pytest
 
 from eflips.ingest.gtfs import GtfsIngester
 from tests.base import BaseIngester
-import gtfs_kit as gk
-
 from tests.conftest import mock_get_altitude
 
 
@@ -456,6 +455,108 @@ class TestGtfsIngester(BaseIngester):
         with open(save_path / "gtfs_data.dill", "rb") as f:
             data = pickle.load(f)
         assert data["agency_name"] == "Agency One / Agency Two"
+
+    # ====================
+    # Route ID Selector Tests (filter_feed_by_route_ids)
+    # ====================
+
+    ALL_SAMPLE_FEED_1_ROUTES = {"AB", "BFC", "STBA", "CITY", "AAMV"}
+
+    @staticmethod
+    def _read_sample_feed_1_with_parent_station(sample_feed_1_path):
+        """Load sample-feed-1 and add an empty parent_station column.
+
+        Mirrors the pre-processing that ``GtfsIngester.prepare`` performs
+        (gtfs.py:160-161). gtfs_kit's ``restrict_to_routes`` raises KeyError on
+        'parent_station' when the column is absent, so direct-method tests
+        must add it the same way ``prepare`` does.
+        """
+        import pandas as pd
+
+        feed = gk.read_feed(sample_feed_1_path, dist_units="m")
+        if feed.stops is not None and "parent_station" not in feed.stops.columns:
+            feed.stops["parent_station"] = pd.NA
+        return feed
+
+    def test_route_ids_single_string(self, ingester, sample_feed_1) -> None:
+        feed = self._read_sample_feed_1_with_parent_station(sample_feed_1)
+        result = ingester.filter_feed_by_route_ids(feed, "AB")
+        assert isinstance(result, gk.Feed)
+        assert set(result.routes["route_id"].astype(str)) == {"AB"}
+        # Cascading: trips should only reference the retained route.
+        assert set(result.trips["route_id"].astype(str)) == {"AB"}
+
+    def test_route_ids_list(self, ingester, sample_feed_1) -> None:
+        feed = self._read_sample_feed_1_with_parent_station(sample_feed_1)
+        result = ingester.filter_feed_by_route_ids(feed, ["AB", "CITY"])
+        assert isinstance(result, gk.Feed)
+        assert set(result.routes["route_id"].astype(str)) == {"AB", "CITY"}
+
+    def test_route_ids_none_is_noop(self, ingester, sample_feed_1) -> None:
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        result = ingester.filter_feed_by_route_ids(feed, None)
+        assert isinstance(result, gk.Feed)
+        assert set(result.routes["route_id"].astype(str)) == self.ALL_SAMPLE_FEED_1_ROUTES
+
+    def test_route_ids_empty_string_is_noop(self, ingester, sample_feed_1) -> None:
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        result = ingester.filter_feed_by_route_ids(feed, "")
+        assert isinstance(result, gk.Feed)
+        assert set(result.routes["route_id"].astype(str)) == self.ALL_SAMPLE_FEED_1_ROUTES
+
+    def test_route_ids_empty_list_is_noop(self, ingester, sample_feed_1) -> None:
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        result = ingester.filter_feed_by_route_ids(feed, [])
+        assert isinstance(result, gk.Feed)
+        assert set(result.routes["route_id"].astype(str)) == self.ALL_SAMPLE_FEED_1_ROUTES
+
+    def test_route_ids_missing_reports_error(self, ingester, sample_feed_1) -> None:
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        result = ingester.filter_feed_by_route_ids(feed, ["AB", "NOPE"])
+        assert isinstance(result, tuple)
+        success, error_dict = result
+        assert success is False
+        assert "route_ids" in error_dict
+        message = error_dict["route_ids"]
+        assert "NOPE" in message
+        # Only "NOPE" is missing; "AB" must not appear in the missing-ids list.
+        missing_line = message.splitlines()[0]
+        assert "AB" not in missing_line
+
+    def test_prepare_with_route_ids(self, ingester, sample_feed_1) -> None:
+        feed = gk.read_feed(sample_feed_1, dist_units="m")
+        validity = ingester.get_feed_validity_period(feed)
+        start_date = datetime.strptime(validity[0], "%Y%m%d").date()
+
+        success, result = ingester.prepare(
+            progress_callback=None,
+            gtfs_zip_file=sample_feed_1,
+            start_date=start_date.isoformat(),
+            duration="DAY",
+            route_ids=["AB", "STBA"],
+        )
+        assert success, result
+        assert isinstance(result, UUID)
+
+        import pickle
+
+        save_path = ingester.path_for_uuid(result)
+        with open(save_path / "gtfs_data.dill", "rb") as f:
+            data = pickle.load(f)
+        saved_feed = data["feed"]
+        assert set(saved_feed.routes["route_id"].astype(str)) == {"AB", "STBA"}
+
+    # ====================
+    # _coerce_str_list Unit Test
+    # ====================
+
+    def test_coerce_str_list(self) -> None:
+        coerce = GtfsIngester._coerce_str_list
+        assert coerce(None) == []
+        assert coerce("") == []
+        assert coerce("x") == ["x"]
+        assert coerce(["a", "", "b"]) == ["a", "b"]
+        assert coerce(("a", None, "b")) == ["a", "b"]
 
 
 class TestParseGtfsTime:


### PR DESCRIPTION
## Summary
- Adds optional `route_ids` parameter to `GtfsIngester.prepare` to restrict an import to specific GTFS route ids
- New `filter_feed_by_route_ids` uses `Feed.restrict_to_routes` so trips, stops, shapes, calendar, and transfers cascade consistently; applied before agency / bus-only filtering
- Factored shared scalar/iterable/None coercion into `_coerce_str_list`; bumps version to 1.6.0

## Test plan
- [x] `black --check`
- [x] `mypy --strict`
- [x] `pytest tests/test_gtfs.py` (sqlite)
- [ ] CI (postgres + sqlite matrix, py3.10–3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)