### PR TITLE
BVGXML rotation merging fix.

### DIFF
--- a/eflips/ingest/bvgxml/_ingester.py
+++ b/eflips/ingest/bvgxml/_ingester.py
@@ -18,16 +18,17 @@ from sqlalchemy.orm import Session
 
 from eflips.ingest.base import AbstractIngester
 from eflips.ingest.bvgxml._pipeline import (
+    RotationRegistry,
     TimeProfile,
     ZERO_DISTANCE_SENTINEL_M,
     create_routes_and_time_profiles,
     create_stations,
     create_trip_prototypes,
     create_trips_and_vehicle_schedules,
+    delete_incomplete_rotations,
     fix_max_sequence,
     identify_and_delete_overlapping_rotations,
     load_and_validate_xml,
-    merge_identical_rotations,
     merge_identical_stations,
     recenter_station,
 )
@@ -43,8 +44,10 @@ class BvgxmlIngester(AbstractIngester):
     schedules are pickled under :meth:`path_for_uuid` for later use.
 
     ``ingest()`` re-uses the helpers in :mod:`eflips.ingest.bvgxml._pipeline` to write stations,
-    routes, trips and rotations into the database, then runs the post-processing fix-ups (geometry
-    recentring, identical-station/rotation merging, overlapping-rotation deletion, sequence reset).
+    routes, trips and rotations into the database — reassembling each vehicle working from its
+    per-line file slices via a shared :class:`RotationRegistry` — then runs the post-processing
+    fix-ups (geometry recentring, identical-station merging, incomplete-rotation deletion,
+    overlapping-rotation deletion, sequence reset).
     """
 
     def prepare(  # type: ignore[override]
@@ -180,10 +183,15 @@ class BvgxmlIngester(AbstractIngester):
                     else:
                         trip_prototypes[fahrt_id] = time_profile
 
+            # One registry for the whole import: it reassembles each physical vehicle working
+            # (which the export slices across one file per line it touches) into one rotation.
+            rotation_registry = RotationRegistry()
             for i, schedule in enumerate(schedules):
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=ConsistencyWarning)
-                    create_trips_and_vehicle_schedules(schedule, trip_prototypes, scenario_id, session)
+                    create_trips_and_vehicle_schedules(
+                        schedule, trip_prototypes, scenario_id, session, rotation_registry
+                    )
                 report_subphase(5, i, n_schedules)
 
             stations_without_geom_q = (
@@ -222,7 +230,7 @@ class BvgxmlIngester(AbstractIngester):
             session.expire_all()
             report(8)
 
-            merge_identical_rotations(scenario_id, session)
+            delete_incomplete_rotations(scenario_id, session)
             report(9)
 
             identify_and_delete_overlapping_rotations(scenario_id, session)

--- a/eflips/ingest/bvgxml/_pipeline.py
+++ b/eflips/ingest/bvgxml/_pipeline.py
@@ -16,18 +16,23 @@ The pipeline runs in this order:
    ``Netzpunkt.haltestellenbereich`` FK and falls back to short-name prefix
    matching) and emits ``Route`` + ``AssocRouteStation`` rows.
 4. :func:`create_trip_prototypes` + :func:`create_trips_and_vehicle_schedules`
-   produce ``Rotation`` / ``Trip`` / ``StopTime`` rows.
+   produce ``Rotation`` / ``Trip`` / ``StopTime`` rows. The export slices the
+   data by Linie, so one physical vehicle working (``Fahrzeugumlauf``) appears
+   in every file whose line it touches, each copy carrying only that line's
+   trips. A cross-file :class:`RotationRegistry` reassembles those slices into
+   a single ``Rotation`` keyed by the working's explicit identity (the ordered
+   ``(UmlaufID, Kalenderdatum)`` pairs of its Umläufe) — no heuristics needed.
 5. :func:`merge_identical_stations` merges duplicate stations grouped by
    short-name prefix, with :data:`STATION_MERGE_GROUPS` as explicit overrides
    for sibling stations whose names don't share a prefix (e.g. depots).
-6. :func:`merge_identical_rotations` chains same-named rotation fragments
-   into a single depot→…→depot rotation. Chains that can't close (because
-   their other half is in an XML file outside the input set) are deleted
-   with a WARNING log — this is the "edge-of-window" cleanup. Depot
-   detection is governed by :data:`DEPOT_NAME_TOKENS`.
+6. :func:`delete_incomplete_rotations` deletes rotations that don't start
+   *and* end at a depot. After step 4's keyed reassembly these are genuine
+   window-edge fragments (the rest of the working lies outside the exported
+   time window); each deletion is logged with a WARNING. Depot detection is
+   governed by :data:`DEPOT_NAME_TOKENS`.
 7. :func:`identify_and_delete_overlapping_rotations` deletes rotations
-   whose trips overlap in time (typically caused by step 6 merging
-   incompatible fragments).
+   whose trips overlap in time (a safety net; after keyed reassembly an
+   overlap indicates contradictory input data).
 8. :func:`fix_max_sequence` repoints sequences so subsequent inserts don't
    collide with the IDs we set explicitly.
 
@@ -46,10 +51,10 @@ import sqlite3
 import statistics
 import warnings
 import zoneinfo
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import psycopg2
 from eflips.model import ConsistencyWarning, Station, Route, AssocRouteStation, StopTime
@@ -978,39 +983,152 @@ def create_trip_prototypes(
     return time_profiles_by_trip_id
 
 
+def _parse_kalenderdatum(value: str) -> date:
+    """Parse the German-format (``DD.MM.YYYY``) ``Kalenderdatum`` of an Umlauf."""
+    day, month, year = (int(part) for part in value.split("."))
+    return date(day=day, month=month, year=year)
+
+
+# The explicit identity of one physical vehicle working: the ordered (UmlaufID, Kalenderdatum)
+# pairs of the Umläufe grouped into one Fahrzeugumlauf element. Every per-line XML file that the
+# working touches repeats the *full* group (verified on the June 2025 BVG dataset: 13,968
+# Fahrzeugumlauf elements collapse into 10,365 groups with zero grouping conflicts), so this tuple
+# joins the per-line slices without any endpoint/time heuristics.
+FahrzeugumlaufKey = Tuple[Tuple[int, date], ...]
+
+
+@dataclass
+class RegisteredRotation:
+    """One physical vehicle working being reassembled from its per-line XML slices."""
+
+    rotation: eflips.model.Rotation
+    betriebshof: int  # home depot code of the Fahrzeugumlauf, used for cross-file consistency checks
+    name: str  # space-joined Umlaufbezeichnungen, e.g. "163/6 N63/9"
+    materialized_fahrt_ids: Set[int] = field(default_factory=set)
+
+
+class RotationRegistry:
+    """
+    Cross-file registry of physical vehicle workings, keyed by :data:`FahrzeugumlaufKey`.
+
+    The BVG-XML export slices the network by Linie: a vehicle working serving several lines
+    appears in each of those lines' files, each copy carrying only the trips of that file's line
+    (all other Fahrtreihenfolgen are empty). One ``RotationRegistry`` instance must be shared
+    across all files of one import so that :func:`create_trips_and_vehicle_schedules` adds every
+    slice's trips to the same :class:`eflips.model.Rotation`.
+
+    The registry is deliberately loud: if two files ever disagree on how Umläufe are grouped into
+    a Fahrzeugumlauf, :meth:`get` raises instead of letting two half-rotations coexist.
+    """
+
+    def __init__(self) -> None:
+        self._by_key: Dict[FahrzeugumlaufKey, RegisteredRotation] = {}
+        self._key_by_member: Dict[Tuple[int, date], FahrzeugumlaufKey] = {}
+
+    def get(self, key: FahrzeugumlaufKey) -> Optional[RegisteredRotation]:
+        """
+        Look up the working for ``key``, or ``None`` if it has not been seen yet.
+
+        :raises ValueError: if ``key`` is unknown but one of its (UmlaufID, Kalenderdatum) members
+            is already registered under a *different* key — i.e. two input files disagree on the
+            grouping of Umläufe into vehicle workings.
+        """
+        entry = self._by_key.get(key)
+        if entry is not None:
+            return entry
+        for member in key:
+            conflicting_key = self._key_by_member.get(member)
+            if conflicting_key is not None:
+                raise ValueError(
+                    f"Inconsistent Fahrzeugumlauf grouping between input files: Umlauf "
+                    f"(UmlaufID={member[0]}, Kalenderdatum={member[1]}) appears both in the group "
+                    f"{conflicting_key} and in the group {key}. The input files contradict each "
+                    f"other about which Umläufe form one vehicle working."
+                )
+        return None
+
+    def add(self, key: FahrzeugumlaufKey, entry: RegisteredRotation) -> None:
+        """Register a newly created working under ``key``."""
+        self._by_key[key] = entry
+        for member in key:
+            self._key_by_member[member] = key
+
+
 def create_trips_and_vehicle_schedules(
-    schedule: Linienfahrplan, trip_prototypes: Dict[int, None | TimeProfile], scenario_id: int, session: Session
+    schedule: Linienfahrplan,
+    trip_prototypes: Dict[int, None | TimeProfile],
+    scenario_id: int,
+    session: Session,
+    rotation_registry: RotationRegistry,
 ) -> None:
     """
-    Creates the trips and vehicle schedules from the parsed Linienfahrplan object
+    Creates the trips and vehicle schedules from the parsed Linienfahrplan object.
+
+    One :class:`eflips.model.Rotation` is created per physical vehicle working (Fahrzeugumlauf).
+    Because the export slices the data by Linie, the same working appears in every file whose line
+    it touches; ``rotation_registry`` (shared across all files of one import) joins those slices
+    back into a single rotation by the working's explicit :data:`FahrzeugumlaufKey`. Cross-file
+    contradictions (different vehicle type, home depot or Umlauf grouping for the same working, or
+    the same trip materialised twice) raise a ``ValueError`` rather than producing garbage
+    rotations.
+
     :param schedule: A parsed Linienfahrplan object
     :param trip_prototypes: A dictionary containing *all* the available time profiles, by their trip.ID. This (rather
            than the *schedule's* time profiles) is used, because the schedule might contain trips that are not in the
            schedule (if a vehicle from this line goes to another line)
     :param scenario_id: The scenario ID to use
     :param session: An open database session
+    :param rotation_registry: The registry joining per-line slices of the same vehicle working; use
+           one instance for all files of an import
     :return: Nothing. The trips are added to the database
     """
     logger = logging.getLogger(__name__)
 
     for fahrzeugumlauf in schedule.fahrzeugumlauf_daten.fahrzeugumlauf:
-        # The Fharzeugumlauf has an Umlaeufe object, which implies there could be multiple.
-        # We do not support this
-        vehicle_type = add_or_ret_vehicle_type(scenario_id, fahrzeugumlauf.fahrzeugtyp, session)
-        rotation = eflips.model.Rotation(
-            scenario_id=scenario_id,
-            id=None,
-            name="",
-            vehicle_type=vehicle_type,
-            allow_opportunity_charging=True,
+        key: FahrzeugumlaufKey = tuple(
+            (umlauf.umlauf_id, _parse_kalenderdatum(umlauf.kalenderdatum)) for umlauf in fahrzeugumlauf.umlaeufe.umlauf
         )
-        session.add(rotation)
-        rotation_trips = []
+        name = " ".join(umlauf.umlaufbezeichnung for umlauf in fahrzeugumlauf.umlaeufe.umlauf)
+        vehicle_type = add_or_ret_vehicle_type(scenario_id, fahrzeugumlauf.fahrzeugtyp, session)
+
+        entry = rotation_registry.get(key)
+        if entry is None:
+            rotation = eflips.model.Rotation(
+                scenario_id=scenario_id,
+                id=None,
+                name=name,
+                vehicle_type=vehicle_type,
+                allow_opportunity_charging=True,
+            )
+            session.add(rotation)
+            entry = RegisteredRotation(rotation=rotation, betriebshof=fahrzeugumlauf.betriebshof, name=name)
+            rotation_registry.add(key, entry)
+        else:
+            # Another file already carries this working; all copies must describe the same vehicle.
+            if entry.name != name:
+                raise ValueError(
+                    f"Vehicle working {key} is named {entry.name!r} in one input file but {name!r} "
+                    f"in another. The input files contradict each other."
+                )
+            if entry.rotation.vehicle_type is not vehicle_type:
+                raise ValueError(
+                    f"Vehicle working {name!r} ({key}) has vehicle type "
+                    f"{entry.rotation.vehicle_type.name_short!r} in one input file but "
+                    f"{vehicle_type.name_short!r} in another. The input files contradict each other."
+                )
+            if entry.betriebshof != fahrzeugumlauf.betriebshof:
+                raise ValueError(
+                    f"Vehicle working {name!r} ({key}) has Betriebshof {entry.betriebshof} in one "
+                    f"input file but {fahrzeugumlauf.betriebshof} in another. The input files "
+                    f"contradict each other."
+                )
+        rotation = entry.rotation
+
+        # This file's slice of the working: only the trips whose line is this file's line have a
+        # populated Fahrtreihenfolge here; the other lines' trips come from their own files.
+        slice_trips: List[eflips.model.Trip] = []
         for xml_rotation in fahrzeugumlauf.umlaeufe.umlauf:
-            date_german = xml_rotation.kalenderdatum.split(".")
-            the_date = date(day=int(date_german[0]), month=int(date_german[1]), year=int(date_german[2]))
-            rotation.name += f"{xml_rotation.umlaufbezeichnung} "
-            # Assemble the list of trips
+            the_date = _parse_kalenderdatum(xml_rotation.kalenderdatum)
             for umlaufteilgruppe in xml_rotation.umlaufteilgruppen.umlaufteilgruppe:
                 if umlaufteilgruppe.fahrtreihenfolge is None:
                     logger.info(
@@ -1018,7 +1136,6 @@ def create_trips_and_vehicle_schedules(
                     )
                     continue
                 # Make sure the vehicle type stays the same
-                part_trips = []
                 for vehicle_type_str in umlaufteilgruppe.fahrzeugtyp:
                     if vehicle_type_str != vehicle_type.name_short:
                         raise ValueError(
@@ -1027,54 +1144,59 @@ def create_trips_and_vehicle_schedules(
                             f"started as {vehicle_type.name_short!r} but Umlaufteilgruppe says "
                             f"{vehicle_type_str!r}."
                         )
-                    for fahrt in umlaufteilgruppe.fahrtreihenfolge.fahrt:
-                        if fahrt.fahrt_id not in trip_prototypes.keys():
-                            raise ValueError(
-                                f"Trip fahrt_id={fahrt.fahrt_id} referenced by Umlauf {xml_rotation.umlauf_id} "
-                                f"(bezeichnung={xml_rotation.umlaufbezeichnung!r}, date={the_date}) is not in "
-                                f"trip_prototypes. This usually means the XML file for the trip's line was not "
-                                f"included in the input zip."
-                            )
-                        tp = trip_prototypes[fahrt.fahrt_id]
-                        if tp is None:
-                            logger.info(
-                                f"Trip {fahrt.fahrt_id} from Umlauf {xml_rotation.umlauf_id} is from a pointless route. Skipping"
-                            )
-                            continue
-                        with session.no_autoflush:  # Get rid of spurious SAWarnings
-                            part_trips.append(tp.to_trip(rotation, the_date))
-                    rotation_trips.extend(part_trips)
+                for fahrt in umlaufteilgruppe.fahrtreihenfolge.fahrt:
+                    if fahrt.fahrt_id not in trip_prototypes.keys():
+                        raise ValueError(
+                            f"Trip fahrt_id={fahrt.fahrt_id} referenced by Umlauf {xml_rotation.umlauf_id} "
+                            f"(bezeichnung={xml_rotation.umlaufbezeichnung!r}, date={the_date}) is not in "
+                            f"trip_prototypes. This usually means the XML file for the trip's line was not "
+                            f"included in the input zip."
+                        )
+                    if fahrt.fahrt_id in entry.materialized_fahrt_ids:
+                        raise ValueError(
+                            f"Trip fahrt_id={fahrt.fahrt_id} of vehicle working {name!r} ({key}) is "
+                            f"materialised by more than one input file. The per-line slices of a "
+                            f"working must be disjoint; the input files contradict each other."
+                        )
+                    tp = trip_prototypes[fahrt.fahrt_id]
+                    if tp is None:
+                        logger.info(
+                            f"Trip {fahrt.fahrt_id} from Umlauf {xml_rotation.umlauf_id} is from a pointless route. Skipping"
+                        )
+                        continue
+                    entry.materialized_fahrt_ids.add(fahrt.fahrt_id)
+                    with session.no_autoflush:  # Get rid of spurious SAWarnings
+                        slice_trips.append(tp.to_trip(rotation, the_date))
 
-            ### SPECIAL FIXES
-            # Do some cleanup. There may be geographical inconsistencies caused by a trip's stop being different from the
-            # stop of the previous trip. This might be caused by a station having multiple "Haltestellenbereiche"
-            # We see if the first four letters of the stations short name are the same, and if so, we change the latter
-            # trip's departure station to the former trip's arrival station
-            for i in range(len(rotation_trips) - 1):
-                cur_trip = rotation_trips[i]
-                next_trip = rotation_trips[i + 1]
-                if cur_trip.stop_times[-1].station != next_trip.stop_times[0].station:
-                    # Two consecutive trips of the same rotation should pick up
-                    # where the previous trip left off. They sometimes don't
-                    # when the same physical place is split across multiple
-                    # Haltestellenbereich rows; merge_identical_stations should
-                    # clean it up later, so this is only an INFO log.
-                    cur_st = cur_trip.stop_times[-1].station
-                    next_st = next_trip.stop_times[0].station
-                    logger.info(
-                        "Rotation %r (date=%s): trip arriving at %r (id=%d) is followed by "
-                        "a trip departing from %r (id=%d). If these are not merged later, "
-                        "the rotation will be flagged for geometric inconsistency.",
-                        rotation.name.strip() or "<pending>",
-                        the_date,
-                        cur_st.name,
-                        cur_st.id,
-                        next_st.name,
-                        next_st.id,
-                    )
-            session.add_all(rotation_trips)
-
-        rotation.name = rotation.name.strip()
+        ### SPECIAL FIXES
+        # Do some cleanup. There may be geographical inconsistencies caused by a trip's stop being different from the
+        # stop of the previous trip. This might be caused by a station having multiple "Haltestellenbereiche"
+        # We see if the first four letters of the stations short name are the same, and if so, we change the latter
+        # trip's departure station to the former trip's arrival station
+        # (Only this file's slice is checked: consecutive trips of the same line. Trips of the
+        # working's other lines interleave temporally but live in other files' slices.)
+        for i in range(len(slice_trips) - 1):
+            cur_trip = slice_trips[i]
+            next_trip = slice_trips[i + 1]
+            if cur_trip.stop_times[-1].station != next_trip.stop_times[0].station:
+                # Two consecutive trips of the same rotation should pick up
+                # where the previous trip left off. They sometimes don't
+                # when the same physical place is split across multiple
+                # Haltestellenbereich rows; merge_identical_stations should
+                # clean it up later, so this is only an INFO log.
+                cur_st = cur_trip.stop_times[-1].station
+                next_st = next_trip.stop_times[0].station
+                logger.info(
+                    "Rotation %r: trip arriving at %r (id=%d) is followed by "
+                    "a trip departing from %r (id=%d). If these are not merged later, "
+                    "the rotation will be flagged for geometric inconsistency.",
+                    name,
+                    cur_st.name,
+                    cur_st.id,
+                    next_st.name,
+                    next_st.id,
+                )
+        session.add_all(slice_trips)
 
 
 def recenter_station(station: eflips.model.Station, session: Session) -> None:
@@ -1367,22 +1489,23 @@ def _name_is_depot(name: str | None) -> bool:
     return any(token in name for token in DEPOT_NAME_TOKENS)
 
 
-def merge_identical_rotations(scenario_id: int, session: Session) -> None:
+def delete_incomplete_rotations(scenario_id: int, session: Session) -> None:
     """
-    Merge rotations with identical names by chaining them depot→…→depot.
+    Delete rotations that do not form a complete depot-to-depot vehicle working.
 
-    Different parts of a single physical rotation may live in different XML
-    files (because the XML is sliced by Linie), so the ingester produces
-    multiple :class:`Rotation` rows for what is conceptually one rotation.
-    This function joins those fragments back together when they form a closed
-    depot-to-depot chain, and deletes fragments that don't (those are partial
-    rotations whose other halves live in XML files outside the input zip —
-    i.e. they fall off the edge of the time window covered by the input).
+    Rotations are reassembled from the per-line XML slices by their explicit Fahrzeugumlauf
+    identity (see :func:`create_trips_and_vehicle_schedules`), so a rotation that does not start
+    *and* end at a depot is a genuine window-edge fragment: the rest of the vehicle working lies
+    outside the time window covered by the input files (e.g. a night bus whose evening half
+    belongs to the day before the export starts). Downstream consumers require depot-to-depot
+    rotations, so such fragments are deleted rather than passed on.
 
-    All deletions are logged at WARNING level with the rotation name, the
-    span of trip dates / endpoint stations involved, and how many trips are
-    being dropped, so callers can tell how much data is lost to edge
-    truncation.
+    The two endpoints do **not** need to be the same depot: real workings park overnight on a
+    satellite Abstellfläche (Betriebshof Lichtenberg → Kaulsdorf Abstellfläche and back exists in
+    the June 2025 BVG dataset). Depot detection is by station name via :data:`DEPOT_NAME_TOKENS`.
+
+    All deletions are logged at WARNING level with the rotation name, its time span, endpoint
+    stations and trip count, so callers can tell how much data is lost to edge truncation.
 
     :param scenario_id: the scenario ID to use
     :param session: an open database session
@@ -1390,129 +1513,52 @@ def merge_identical_rotations(scenario_id: int, session: Session) -> None:
     """
     logger = logging.getLogger(__name__)
 
-    rotation_names = (
-        session.query(eflips.model.Rotation.name)
-        .filter(eflips.model.Rotation.scenario_id == scenario_id)
-        .group_by(eflips.model.Rotation.name)
-        .all()
-    )
-    for rotation_name in rotation_names:
-        all_rots_for_name = (
-            session.query(eflips.model.Rotation)
-            .filter(eflips.model.Rotation.name == rotation_name[0])
-            .filter(eflips.model.Rotation.scenario_id == scenario_id)
-            .all()
-        )
-        # Order them by the first trip's departure time
-        all_rots_for_name = sorted(all_rots_for_name, key=lambda rot: rot.trips[0].departure_time)
-
-        list_of_rotation_id_tuples_to_merge: List[List[int]] = []
-        rotation_ids_to_merge: List[int] = []
-
-        for rotation in all_rots_for_name:
-            first_station_name = rotation.trips[0].route.departure_station.name
-            last_station_name = rotation.trips[-1].route.arrival_station.name
-            first_station_departure_time = rotation.trips[0].departure_time
-            last_station_arrival_time = rotation.trips[-1].arrival_time
-
-            if _name_is_depot(first_station_name) and _name_is_depot(last_station_name):
-                # This is a rotation that starts and ends at the depot
-                # We don't need to merge it with anything
-                continue
-            elif _name_is_depot(first_station_name) and not _name_is_depot(last_station_name):
-                # This rotation starts at the depot and ends somewhere else
-                # Start a new list after appending the current list to the list of lists
-                list_of_rotation_id_tuples_to_merge.append(rotation_ids_to_merge)
-                rotation_ids_to_merge = [rotation.id]
-            elif not _name_is_depot(first_station_name) and _name_is_depot(last_station_name):
-                # This rotation starts somewhere else and ends at the depot
-                # Append the current rotation to the list
-                rotation_ids_to_merge.append(rotation.id)
-                list_of_rotation_id_tuples_to_merge.append(rotation_ids_to_merge)
-                rotation_ids_to_merge = []
-            elif not _name_is_depot(first_station_name) and not _name_is_depot(last_station_name):
-                # This rotation starts and ends somewhere else
-                # Append the current rotation to the list
-                rotation_ids_to_merge.append(rotation.id)
-            else:
-                # All four (depot, depot) / (depot, ¬depot) / (¬depot, depot) / (¬depot, ¬depot)
-                # branches are covered above; this is genuinely unreachable.
-                raise ValueError(
-                    f"Unreachable branch in merge_identical_rotations for rotation "
-                    f"name={rotation.name!r} id={rotation.id} "
-                    f"start={first_station_name!r} end={last_station_name!r}."
-                )
-
-        # Remove empty lists
-        list_of_rotation_id_tuples_to_merge = [x for x in list_of_rotation_id_tuples_to_merge if len(x) > 0]
-
-        # Go through the list of lists and merge the rotations, if they form a valid rotation
-        for rotation_ids_to_merge in list_of_rotation_id_tuples_to_merge:
-            rotations = (
-                session.query(eflips.model.Rotation).filter(eflips.model.Rotation.id.in_(rotation_ids_to_merge)).all()
+    rotations = session.query(eflips.model.Rotation).filter(eflips.model.Rotation.scenario_id == scenario_id).all()
+    n_deleted = 0
+    n_trips_deleted = 0
+    for rotation in rotations:
+        if len(rotation.trips) == 0:
+            # Possible if every referenced trip sat on a "pointless" (single-station) route.
+            logger.warning(
+                "Deleting rotation name=%r (id=%d): it contains no trips at all.",
+                rotation.name,
+                rotation.id,
             )
-            # Order the rotations by the first trip's departure time
-            rotations = sorted(rotations, key=lambda rot: rot.trips[0].departure_time)
+            session.delete(rotation)
+            n_deleted += 1
+            continue
 
-            # Check whether the rotations can be merged
-            # The first station of the first rotation must be the same as the last station of the last rotation
-            # And both must contain "Betriebshof"
-            if (
-                rotations[0].trips[0].route.departure_station.name != rotations[-1].trips[-1].route.arrival_station.name
-                or not (_name_is_depot(rotations[0].trips[0].route.departure_station.name))
-                or not (_name_is_depot(rotations[-1].trips[-1].route.arrival_station.name))
-            ):
-                first_dep = rotations[0].trips[0].route.departure_station.name
-                last_arr = rotations[-1].trips[-1].route.arrival_station.name
-                first_time = rotations[0].trips[0].departure_time
-                last_time = rotations[-1].trips[-1].arrival_time
-                trip_count = sum(len(r.trips) for r in rotations)
-                if first_dep == last_arr:
-                    reason = (
-                        f"endpoints match ({first_dep!r}) but are not a known depot. "
-                        f"Add the station to DEPOT_NAME_TOKENS if it should be treated as one."
-                    )
-                else:
-                    reason = (
-                        f"chain start {first_dep!r} != chain end {last_arr!r}; "
-                        f"this is the typical signature of a partial rotation whose other "
-                        f"half is in an XML file outside the input zip (edge-of-window)."
-                    )
-                logger.warning(
-                    "Deleting %d-fragment rotation chain name=%r (%d trips, %s → %s): %s",
-                    len(rotations),
-                    rotations[0].name,
-                    trip_count,
-                    first_time.isoformat() if first_time else None,
-                    last_time.isoformat() if last_time else None,
-                    reason,
-                )
-                # If the merge is not possible we delete these rotations
-                for rotation in rotations:
-                    for trip in rotation.trips:
-                        for stop_time in trip.stop_times:
-                            session.delete(stop_time)
-                        session.delete(trip)
-                    session.delete(rotation)
-            else:
-                # Merge the rotations by creating a new rotation
-                new_rotation = eflips.model.Rotation(
-                    name=rotations[0].name,
-                    scenario_id=rotations[0].scenario_id,
-                    vehicle_type_id=rotations[0].vehicle_type_id,
-                    allow_opportunity_charging=rotations[0].allow_opportunity_charging,
-                )
-                session.add(new_rotation)
-                session.flush()
-                for rotation in rotations:
-                    session.query(eflips.model.Trip).filter(eflips.model.Trip.rotation_id == rotation.id).update(
-                        {"rotation_id": new_rotation.id}
-                    )
-                    session.refresh(
-                        rotation
-                    )  # Refresh the rotation object to get the updated trips (there are now none)
-                    session.delete(rotation)
-                    session.flush()
+        first_station_name = rotation.trips[0].route.departure_station.name
+        last_station_name = rotation.trips[-1].route.arrival_station.name
+        if _name_is_depot(first_station_name) and _name_is_depot(last_station_name):
+            continue
+
+        logger.warning(
+            "Deleting incomplete rotation name=%r (%d trips, %s → %s, %r → %r): it does not run "
+            "depot-to-depot. This is the signature of a window-edge fragment — the rest of the "
+            "vehicle working lies outside the time window covered by the input files. If the "
+            "endpoint *is* a depot, add its name to DEPOT_NAME_TOKENS.",
+            rotation.name,
+            len(rotation.trips),
+            rotation.trips[0].departure_time.isoformat(),
+            rotation.trips[-1].arrival_time.isoformat(),
+            first_station_name,
+            last_station_name,
+        )
+        n_trips_deleted += len(rotation.trips)
+        for trip in rotation.trips:
+            for stop_time in trip.stop_times:
+                session.delete(stop_time)
+            session.delete(trip)
+        session.delete(rotation)
+        n_deleted += 1
+    session.flush()
+    logger.info(
+        "Incomplete-rotation cleanup: deleted %d of %d rotations (%d trips).",
+        n_deleted,
+        len(rotations),
+        n_trips_deleted,
+    )
 
 
 def identify_and_delete_overlapping_rotations(scenario_id: int, session: Session) -> None:

--- a/eflips/ingest/vdv/_ingester.py
+++ b/eflips/ingest/vdv/_ingester.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Dict, IO, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, IO, List, Optional, Set, Tuple, Union, cast
 from uuid import UUID, uuid4
 from zipfile import ZipFile
 
@@ -358,6 +358,9 @@ _ONR_TYP_BHOF = 2
 _ONR_TYP_BP = 6
 _ONR_TYP_DEPOT = frozenset({_ONR_TYP_BHOF, _ONR_TYP_BP})
 
+# Opaque identity of one fragment: unique and sortable, contents otherwise uninterpreted.
+FragmentKey = Tuple[Any, ...]
+
 
 @dataclass(frozen=True)
 class RotationFragment:
@@ -368,7 +371,7 @@ class RotationFragment:
     with equality semantics (ORM instances in production, plain strings in tests).
     """
 
-    key: Tuple  # unique and sortable; used for deterministic tie-breaking
+    key: FragmentKey  # unique and sortable; used for deterministic tie-breaking
     start_station: object
     start_time: datetime
     end_station: object
@@ -381,7 +384,7 @@ class RotationFragment:
 
 def match_rotation_fragments(
     fragments: List[RotationFragment], max_gap: timedelta = _MAX_CHAIN_GAP
-) -> List[Tuple[Tuple, Tuple]]:
+) -> List[Tuple[FragmentKey, FragmentKey]]:
     """
     Match open rotation fragments into (predecessor, successor) pairs under the hard constraints
     described above. Rotations that start *and* end at a depot are closed and never take part.
@@ -394,7 +397,7 @@ def match_rotation_fragments(
     for f in sorted((f for f in fragments if not f.end_at_depot), key=lambda f: f.key):
         tails_by_station_and_type[(f.end_station, f.vehicle_type)].append(f)
 
-    candidates: List[Tuple[timedelta, Tuple, Tuple]] = []
+    candidates: List[Tuple[timedelta, FragmentKey, FragmentKey]] = []
     for s in sorted((f for f in fragments if not f.start_at_depot), key=lambda f: f.key):
         for p in tails_by_station_and_type.get((s.start_station, s.vehicle_type), []):
             if p.key == s.key:
@@ -408,9 +411,9 @@ def match_rotation_fragments(
     # Greedy 1:1, smallest gap first. Cycles cannot arise: every link consumes non-negative time and
     # every fragment has positive duration, so a chain can never return to its own start.
     candidates.sort()
-    used_pred: set = set()
-    used_succ: set = set()
-    pairs: List[Tuple[Tuple, Tuple]] = []
+    used_pred: Set[FragmentKey] = set()
+    used_succ: Set[FragmentKey] = set()
+    pairs: List[Tuple[FragmentKey, FragmentKey]] = []
     for gap, p_key, s_key in candidates:
         if p_key in used_pred or s_key in used_succ:
             continue
@@ -422,9 +425,9 @@ def match_rotation_fragments(
 
 def chain_rotation_fragments(
     session: Session,
-    rotations_by_key: Dict[Tuple, Rotation],
-    home_depot_by_rotation_pk: Dict[Tuple, Optional[int]],
-    depot_stations: set,
+    rotations_by_key: Dict[Tuple[Any, ...], Rotation],
+    home_depot_by_rotation_pk: Dict[Tuple[Any, ...], Optional[int]],
+    depot_stations: Set[Any],
     debug: "_DebugSink",
     max_gap: timedelta = _MAX_CHAIN_GAP,
 ) -> None:
@@ -441,7 +444,7 @@ def chain_rotation_fragments(
     logger = logging.getLogger(__name__)
 
     fragments: List[RotationFragment] = []
-    rotation_by_fragment_key: Dict[Tuple, Rotation] = {}
+    rotation_by_fragment_key: Dict[FragmentKey, Rotation] = {}
     for key in sorted(rotations_by_key.keys()):
         rotation = rotations_by_key[key]
         if len(rotation.trips) == 0:
@@ -475,7 +478,7 @@ def chain_rotation_fragments(
     # mid-chain, the aborted successor is re-queued here as a fresh root so its own downstream
     # links still get built instead of being silently dropped with the discarded predecessor.
     roots = deque(sorted(k for k in succ_of.keys() if k not in has_pred))
-    processed: set = set()
+    processed: Set[FragmentKey] = set()
     while roots:
         root_key = roots.popleft()
         if root_key in processed:
@@ -1160,9 +1163,7 @@ class VdvIngester(AbstractIngester):
                 # boundary) into full depot-to-depot rotations. See the module comment on
                 # match_rotation_fragments for the evidence behind the matching rules.
                 if not os.environ.get("EFLIPS_VDV_DISABLE_FRAGMENT_CHAINING"):
-                    depot_stations = {
-                        station for pk, station in stations_by_vdv_pk.items() if pk[1] in _ONR_TYP_DEPOT
-                    }
+                    depot_stations = {station for pk, station in stations_by_vdv_pk.items() if pk[1] in _ONR_TYP_DEPOT}
                     home_depot_by_rotation_pk = {
                         pk: vdv_rotation.bhof_ort_nr for pk, vdv_rotation in vdv_rotations_by_pk.items()
                     }

--- a/eflips/ingest/vdv/_ingester.py
+++ b/eflips/ingest/vdv/_ingester.py
@@ -6,7 +6,7 @@ import logging
 import os
 import pickle
 import re
-from collections import defaultdict
+from collections import defaultdict, deque
 from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
@@ -313,6 +313,236 @@ def normalize_trip_offsets(
             step = timedelta(seconds=step_seconds[i])
             new_dwells.append(max(timedelta(0), min(dwell_durations[i], step)))
     return new_offsets, new_dwells
+
+
+# ── Rotation fragment chaining ──────────────────────────────────────────────────────────────────
+#
+# IVU.plan VDV exports cut a vehicle's working day into per-Umlauf *fragments*: REC_UMLAUF rows that
+# begin or end at an ordinary stop rather than at a depot. This happens at line changes (the same bus
+# continues under the next line's Umlauf number) and at the ~03:00 service-day boundary (night buses
+# parked at a street terminal are fetched by the next service day's Umlauf). Downstream consumers
+# require depot-to-depot rotations, so unchained fragments would be discarded there — together with
+# all their revenue kilometres.
+#
+# We therefore re-join fragments into full vehicle workings. There is no explicit chain table to use
+# (REC_UMS is empty in real exports; REC_ABLOESESTELLE covers driver reliefs only), so the join is
+# reconstructed from physical continuity, with *hard* constraints only:
+#
+#   * the successor's first departure station is the predecessor's last arrival station,
+#   * both fragments use the same vehicle type (validated on BVG data: greedy matching without this
+#     constraint pairs e.g. the typ-1022 'N20/74' with the typ-1013 'N20/72' on gap alone, while the
+#     1022 bus actually continues as day-line '220/10'),
+#   * both fragments belong to the same home depot (BHOF_ORT_NR; 436 of 437 pairs in the validation
+#     dataset agree on it — treated as satisfied when either side does not declare one),
+#   * the time gap is non-negative (no overlap) and at most _MAX_CHAIN_GAP (largest genuine gap
+#     observed is ~24 h: a bus positioned at a terminal in the early morning and picked up by the
+#     following night service).
+#
+# Umlauf *names* are deliberately not compared: IVU renumbers Umläufe per line and per service day,
+# so almost every genuine continuation changes its name (only 1 of 437 validated pairs kept it).
+#
+# Ambiguity (several same-type buses parked at the same stop) is resolved 1:1, smallest gap first,
+# with fully specified tie-breakers. Swapping two interchangeable buses does not change the
+# simulation outcome, so any deterministic feasible assignment is equally valid. Unmatched fragments
+# (working chains that cross the export window boundary, or vehicles that continue on lines outside
+# the exported subset) are left untouched.
+
+_MAX_CHAIN_GAP = timedelta(hours=30)
+
+# MENGE_ONR_TYP: 1 = HP (passenger stop), 2 = BHOF (depot point), 6 = BP (operational point).
+# Both BHOF and BP are treated as depot-like endpoints where a rotation may open/close: the
+# zero-duration deadhead handling (see the "Private / Linienwagen" synthesis below) also anchors
+# synthetic depot trips at BP-typed places, so a rotation closed there must not be mistaken for an
+# open fragment by the chainer.
+_ONR_TYP_BHOF = 2
+_ONR_TYP_BP = 6
+_ONR_TYP_DEPOT = frozenset({_ONR_TYP_BHOF, _ONR_TYP_BP})
+
+
+@dataclass(frozen=True)
+class RotationFragment:
+    """
+    Endpoint summary of one materialised rotation, the unit of :func:`match_rotation_fragments`.
+
+    ``start_station`` / ``end_station`` / ``vehicle_type`` are opaque identity tokens — any objects
+    with equality semantics (ORM instances in production, plain strings in tests).
+    """
+
+    key: Tuple  # unique and sortable; used for deterministic tie-breaking
+    start_station: object
+    start_time: datetime
+    end_station: object
+    end_time: datetime
+    start_at_depot: bool
+    end_at_depot: bool
+    vehicle_type: object
+    home_depot: Optional[int]  # BHOF_ORT_NR; None = not declared
+
+
+def match_rotation_fragments(
+    fragments: List[RotationFragment], max_gap: timedelta = _MAX_CHAIN_GAP
+) -> List[Tuple[Tuple, Tuple]]:
+    """
+    Match open rotation fragments into (predecessor, successor) pairs under the hard constraints
+    described above. Rotations that start *and* end at a depot are closed and never take part.
+
+    :return: List of ``(predecessor.key, successor.key)`` pairs. Each fragment appears at most once
+        as predecessor and at most once as successor; transitive pairs form longer chains.
+    """
+    zero = timedelta(0)
+    tails_by_station_and_type: Dict[Tuple[object, object], List[RotationFragment]] = defaultdict(list)
+    for f in sorted((f for f in fragments if not f.end_at_depot), key=lambda f: f.key):
+        tails_by_station_and_type[(f.end_station, f.vehicle_type)].append(f)
+
+    candidates: List[Tuple[timedelta, Tuple, Tuple]] = []
+    for s in sorted((f for f in fragments if not f.start_at_depot), key=lambda f: f.key):
+        for p in tails_by_station_and_type.get((s.start_station, s.vehicle_type), []):
+            if p.key == s.key:
+                continue
+            if p.home_depot is not None and s.home_depot is not None and p.home_depot != s.home_depot:
+                continue
+            gap = s.start_time - p.end_time
+            if zero <= gap <= max_gap:
+                candidates.append((gap, p.key, s.key))
+
+    # Greedy 1:1, smallest gap first. Cycles cannot arise: every link consumes non-negative time and
+    # every fragment has positive duration, so a chain can never return to its own start.
+    candidates.sort()
+    used_pred: set = set()
+    used_succ: set = set()
+    pairs: List[Tuple[Tuple, Tuple]] = []
+    for gap, p_key, s_key in candidates:
+        if p_key in used_pred or s_key in used_succ:
+            continue
+        used_pred.add(p_key)
+        used_succ.add(s_key)
+        pairs.append((p_key, s_key))
+    return pairs
+
+
+def chain_rotation_fragments(
+    session: Session,
+    rotations_by_key: Dict[Tuple, Rotation],
+    home_depot_by_rotation_pk: Dict[Tuple, Optional[int]],
+    depot_stations: set,
+    debug: "_DebugSink",
+    max_gap: timedelta = _MAX_CHAIN_GAP,
+) -> None:
+    """
+    Join materialised open rotation fragments into full vehicle workings (see module comment above).
+
+    :param rotations_by_key: Materialised rotations keyed by ``(basis_version, tagesart_nr, um_uid,
+        date)``. Rotations without trips are ignored.
+    :param home_depot_by_rotation_pk: ``RecUmlauf.bhof_ort_nr`` keyed by ``(basis_version,
+        tagesart_nr, um_uid)``.
+    :param depot_stations: Stations that represent a depot (any VDV ort with ONR_TYP_NR in
+        {2 (BHOF), 6 (BP)} maps to them). Fragments are only chained at non-depot stations.
+    """
+    logger = logging.getLogger(__name__)
+
+    fragments: List[RotationFragment] = []
+    rotation_by_fragment_key: Dict[Tuple, Rotation] = {}
+    for key in sorted(rotations_by_key.keys()):
+        rotation = rotations_by_key[key]
+        if len(rotation.trips) == 0:
+            continue
+        trips = sorted(rotation.trips, key=lambda t: (t.departure_time, t.arrival_time))
+        first_trip, last_trip = trips[0], trips[-1]
+        fragment_key = (key[0], key[1], key[2], key[3].isoformat())
+        fragments.append(
+            RotationFragment(
+                key=fragment_key,
+                start_station=first_trip.route.departure_station,
+                start_time=first_trip.departure_time,
+                end_station=last_trip.route.arrival_station,
+                end_time=last_trip.arrival_time,
+                start_at_depot=first_trip.route.departure_station in depot_stations,
+                end_at_depot=last_trip.route.arrival_station in depot_stations,
+                vehicle_type=rotation.vehicle_type,
+                home_depot=home_depot_by_rotation_pk.get((key[0], key[1], key[2])),
+            )
+        )
+        rotation_by_fragment_key[fragment_key] = rotation
+
+    n_open = sum(int(not f.start_at_depot) + int(not f.end_at_depot) for f in fragments)
+    pairs = match_rotation_fragments(fragments, max_gap)
+
+    succ_of = dict(pairs)
+    has_pred = {s for _, s in pairs}
+    n_merged_fragments = 0
+    n_chains = 0
+    # Chain roots are the fragments with no predecessor. If the safety net below aborts a link
+    # mid-chain, the aborted successor is re-queued here as a fresh root so its own downstream
+    # links still get built instead of being silently dropped with the discarded predecessor.
+    roots = deque(sorted(k for k in succ_of.keys() if k not in has_pred))
+    processed: set = set()
+    while roots:
+        root_key = roots.popleft()
+        if root_key in processed:
+            continue
+        processed.add(root_key)
+        head = rotation_by_fragment_key[root_key]
+        member_names = [str(head.name)]
+        member_keys = [root_key]
+        key = root_key
+        while key in succ_of:
+            successor_key = succ_of[key]
+            successor = rotation_by_fragment_key[successor_key]
+            # Safety net: the matcher already guarantees non-overlap, so this only fires if the
+            # matcher and the trips it saw ever get out of sync. Better to leave two open fragments
+            # (dropped downstream) than to build a rotation with overlapping trips.
+            head_last_arrival = max(t.arrival_time for t in head.trips)
+            successor_first_departure = min(t.departure_time for t in successor.trips)
+            if successor_first_departure < head_last_arrival:
+                logger.warning(
+                    f"Not chaining rotation {successor.name!r} onto {head.name!r}: it departs "
+                    f"{successor_first_departure} before the chain's last arrival {head_last_arrival}."
+                )
+                debug.log(
+                    "fragment_chain_link_rejected",
+                    chain_head=list(root_key),
+                    successor=list(successor_key),
+                    head_last_arrival=head_last_arrival,
+                    successor_first_departure=successor_first_departure,
+                )
+                # The aborted successor may itself head a valid downstream chain; process it as a
+                # new root so C->D in A->B->C->D survives even when B->C is rejected.
+                roots.append(successor_key)
+                break
+            for trip in list(successor.trips):
+                trip.rotation = head
+            member_names.append(str(successor.name))
+            member_keys.append(successor_key)
+            processed.add(successor_key)
+            session.delete(successor)
+            n_merged_fragments += 1
+            key = successor_key
+        if len(member_names) > 1:
+            head.name = " + ".join(member_names)
+            n_chains += 1
+            debug.log(
+                "fragment_chain_merged",
+                chain_head=list(root_key),
+                members=[list(k) for k in member_keys],
+                name=head.name,
+            )
+    session.flush()
+
+    n_still_open = n_open - 2 * n_merged_fragments  # each executed join closes one tail and one head
+    logger.info(
+        f"Rotation fragment chaining: {len(fragments)} rotations, {n_open} open fragment endpoints "
+        f"before, {n_merged_fragments} joins into {n_chains} chained rotations, "
+        f"{n_still_open} open endpoints left (export-window edges or vehicles leaving the exported "
+        f"line subset)."
+    )
+    debug.log(
+        "fragment_chain_summary",
+        n_rotations=len(fragments),
+        n_open_endpoints=n_open,
+        n_joins=n_merged_fragments,
+        n_chained_rotations=n_chains,
+        n_open_endpoints_left=n_still_open,
+    )
 
 
 class VdvIngester(AbstractIngester):
@@ -925,6 +1155,24 @@ class VdvIngester(AbstractIngester):
                 for rotation in list(scenario.rotations):
                     if len(rotation.trips) == 0:
                         session.delete(rotation)
+
+                # Re-join rotation fragments (vehicle workings cut at line changes / the service-day
+                # boundary) into full depot-to-depot rotations. See the module comment on
+                # match_rotation_fragments for the evidence behind the matching rules.
+                if not os.environ.get("EFLIPS_VDV_DISABLE_FRAGMENT_CHAINING"):
+                    depot_stations = {
+                        station for pk, station in stations_by_vdv_pk.items() if pk[1] in _ONR_TYP_DEPOT
+                    }
+                    home_depot_by_rotation_pk = {
+                        pk: vdv_rotation.bhof_ort_nr for pk, vdv_rotation in vdv_rotations_by_pk.items()
+                    }
+                    chain_rotation_fragments(
+                        session,
+                        rotations_by_vdv_pk_and_date,
+                        home_depot_by_rotation_pk,
+                        depot_stations,
+                        debug,
+                    )
 
                 session.commit()
                 debug.log("ingest_complete")

--- a/eflips/ingest/vdv/_xmldata.py
+++ b/eflips/ingest/vdv/_xmldata.py
@@ -4,6 +4,7 @@
 Generator: DataclassGenerator
 See: https://xsdata.readthedocs.io/
 """
+
 import logging
 from abc import ABC, abstractmethod
 from collections import Counter
@@ -1185,6 +1186,13 @@ class RecUmlauf(VdvBaseObject):
     Identifier of the vehicle type to take on theis rotation
     """
 
+    bhof_ort_nr: Optional[int] = None
+    """
+    ORT_NR of this rotation's home depot (Betriebshof). Not part of the rotation's identity, but used as a
+    hard constraint when chaining open rotation fragments: two fragments may only be joined into one
+    vehicle working if they belong to the same home depot.
+    """
+
     @property
     def primary_key(self) -> PrimaryKey:
         return self.basis_version, self.tagesart_nr, self.um_uid
@@ -1211,9 +1219,16 @@ class RecUmlauf(VdvBaseObject):
             anf_onr_typ=data["ANF_ONR_TYP"],
             end_ort=data["END_ORT"],
             end_onr_typ=data["END_ONR_TYP"],
-            fzg_typ_nr=data["FZG_TYP_NR"]
-            if "FZG_TYP_NR" in data.keys() and isinstance(data["FZG_TYP_NR"], int) and data["FZG_TYP_NR"] != 0
-            else None,
+            fzg_typ_nr=(
+                data["FZG_TYP_NR"]
+                if "FZG_TYP_NR" in data.keys() and isinstance(data["FZG_TYP_NR"], int) and data["FZG_TYP_NR"] != 0
+                else None
+            ),
+            bhof_ort_nr=(
+                data["BHOF_ORT_NR"]
+                if "BHOF_ORT_NR" in data.keys() and isinstance(data["BHOF_ORT_NR"], int) and data["BHOF_ORT_NR"] != 0
+                else None
+            ),
         )
 
     def to_rotation(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "2.0.1"
+version = "2.1.0"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/test_bvgxml.py
+++ b/tests/test_bvgxml.py
@@ -17,6 +17,8 @@ from eflips.ingest.bvgxml._pipeline import (
     setup_working_dictionaries,
     create_routes_and_time_profiles,
     create_trip_prototypes,
+    RegisteredRotation,
+    RotationRegistry,
     TimeProfile,
     create_trips_and_vehicle_schedules,
     recenter_station,
@@ -169,7 +171,7 @@ class TestBVGXML:
             trips_by_id: Dict[int, TimeProfile] = create_trip_prototypes(
                 linienfahrplan, trip_time_profiles, db_routes_by_lfd_nr
             )
-            create_trips_and_vehicle_schedules(linienfahrplan, trips_by_id, scenario_id, session)
+            create_trips_and_vehicle_schedules(linienfahrplan, trips_by_id, scenario_id, session, RotationRegistry())
 
     def test_create_working_data(self, linienfahrplan):
         grid_points, segments, route_datas, route_lfd_nrs = setup_working_dictionaries(linienfahrplan)
@@ -423,3 +425,314 @@ class TestBvgxmlIngester(BaseIngester):
             )
             assert len(scenarios) == 2
             assert scenarios[0].id != scenarios[1].id
+
+
+# ---------------------------------------------------------------------------
+# Rotation reassembly (RotationRegistry / create_trips_and_vehicle_schedules)
+# and window-edge cleanup (delete_incomplete_rotations).
+#
+# These are DB-free: fakes stand in for the ORM session, mirroring the style
+# of the chain_rotation_fragments tests in test_vdv_unit.py.
+# ---------------------------------------------------------------------------
+
+from datetime import date, datetime, timedelta
+from types import SimpleNamespace
+
+from eflips.ingest.bvgxml import _pipeline
+from eflips.ingest.bvgxml._pipeline import (
+    _parse_kalenderdatum,
+    delete_incomplete_rotations,
+)
+
+
+class _NoAutoflush:
+    def __enter__(self) -> "_NoAutoflush":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakeQuery:
+    def __init__(self, items: list) -> None:
+        self._items = items
+
+    def filter(self, *args: object) -> "_FakeQuery":
+        return self
+
+    def all(self) -> list:
+        return self._items
+
+
+class _FakeSession:
+    def __init__(self, rotations: list | None = None) -> None:
+        self.added: list = []
+        self.deleted: list = []
+        self.no_autoflush = _NoAutoflush()
+        self._rotations = rotations if rotations is not None else []
+
+    def add(self, obj: object) -> None:
+        self.added.append(obj)
+
+    def add_all(self, objs: list) -> None:
+        self.added.extend(objs)
+
+    def delete(self, obj: object) -> None:
+        self.deleted.append(obj)
+
+    def flush(self) -> None:
+        pass
+
+    def query(self, *args: object) -> _FakeQuery:
+        return _FakeQuery(self._rotations)
+
+
+class _FakePrototype:
+    """Stands in for a TimeProfile; records which rotation each trip was attached to."""
+
+    _STATION = SimpleNamespace(name="Somewhere", id=0)
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def to_trip(self, rotation: object, the_date: date) -> SimpleNamespace:
+        self.calls.append((rotation, the_date))
+        return SimpleNamespace(rotation=rotation, stop_times=[SimpleNamespace(station=self._STATION)])
+
+
+def _schedule(*fahrzeugumlaeufe: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(fahrzeugumlauf_daten=SimpleNamespace(fahrzeugumlauf=list(fahrzeugumlaeufe)))
+
+
+def _fahrzeugumlauf(
+    umlaeufe: "list[tuple[int, str, str]]",
+    fahrt_ids_by_umlauf: "dict[int, list[int]]",
+    betriebshof: int = 9424,
+    fahrzeugtyp: str = "GEG",
+) -> SimpleNamespace:
+    """
+    Build a Fahrzeugumlauf fake. ``umlaeufe`` is a list of (umlauf_id, kalenderdatum,
+    bezeichnung); ``fahrt_ids_by_umlauf`` gives each Umlauf's materialised FahrtIDs in this
+    file's slice (an empty list models the empty Fahrtreihenfolge of a foreign line's copy).
+    """
+    umlauf_fakes = []
+    for umlauf_id, kalenderdatum, bezeichnung in umlaeufe:
+        fahrten = [SimpleNamespace(fahrt_id=fid) for fid in fahrt_ids_by_umlauf.get(umlauf_id, [])]
+        teilgruppe = SimpleNamespace(
+            fahrzeugtyp=[fahrzeugtyp],
+            fahrtreihenfolge=SimpleNamespace(fahrt=fahrten) if fahrten else None,
+        )
+        umlauf_fakes.append(
+            SimpleNamespace(
+                umlauf_id=umlauf_id,
+                kalenderdatum=kalenderdatum,
+                umlaufbezeichnung=bezeichnung,
+                umlaufteilgruppen=SimpleNamespace(umlaufteilgruppe=[teilgruppe]),
+            )
+        )
+    return SimpleNamespace(
+        betriebshof=betriebshof,
+        fahrzeugtyp=fahrzeugtyp,
+        umlaeufe=SimpleNamespace(umlauf=umlauf_fakes),
+    )
+
+
+@pytest.fixture
+def fake_vehicle_types(monkeypatch) -> dict:
+    """Replace add_or_ret_vehicle_type with a per-name singleton cache of VehicleType fakes."""
+    cache: dict = {}
+
+    def _fake(scenario_id: int, fahrzeugtyp: str, session: object) -> SimpleNamespace:
+        if fahrzeugtyp not in cache:
+            cache[fahrzeugtyp] = eflips.model.VehicleType(
+                scenario_id=scenario_id,
+                name=fahrzeugtyp,
+                name_short=fahrzeugtyp,
+                battery_capacity=100,
+                charging_curve=[[0, 150], [1, 150]],
+                opportunity_charging_capable=False,
+            )
+        return cache[fahrzeugtyp]
+
+    monkeypatch.setattr(_pipeline, "add_or_ret_vehicle_type", _fake)
+    return cache
+
+
+class TestParseKalenderdatum:
+    def test_parses_german_date(self) -> None:
+        assert _parse_kalenderdatum("16.06.2025") == date(2025, 6, 16)
+
+
+class TestRotationRegistry:
+    KEY_A = ((1, date(2025, 6, 16)), (2, date(2025, 6, 17)))
+    KEY_B = ((3, date(2025, 6, 16)),)
+
+    def _entry(self) -> RegisteredRotation:
+        return RegisteredRotation(rotation=SimpleNamespace(), betriebshof=9424, name="100/1 N02/1")
+
+    def test_get_unknown_key_returns_none(self) -> None:
+        assert RotationRegistry().get(self.KEY_A) is None
+
+    def test_add_then_get_returns_entry(self) -> None:
+        registry = RotationRegistry()
+        entry = self._entry()
+        registry.add(self.KEY_A, entry)
+        assert registry.get(self.KEY_A) is entry
+        assert registry.get(self.KEY_B) is None
+
+    def test_conflicting_grouping_raises(self) -> None:
+        # A second file groups Umlauf (2, 17.06.) with a different partner: the files contradict
+        # each other about which Umlaeufe form one vehicle working. Must be loud, not silent.
+        registry = RotationRegistry()
+        registry.add(self.KEY_A, self._entry())
+        overlapping_key = ((2, date(2025, 6, 17)), (4, date(2025, 6, 18)))
+        with pytest.raises(ValueError, match="Inconsistent Fahrzeugumlauf grouping"):
+            registry.get(overlapping_key)
+
+
+class TestRotationReassembly:
+    """create_trips_and_vehicle_schedules must join the per-line file slices of one physical
+    vehicle working into a single rotation, and crash on contradictory input."""
+
+    def test_two_file_slices_share_one_rotation(self, fake_vehicle_types) -> None:
+        # The '106/2' working serves lines 106 and 204. The 106 file materialises only the 106
+        # trips, the 204 file only the 204 trips; both carry the full Umlauf group.
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype(), 12: _FakePrototype(), 21: _FakePrototype()}
+
+        file_106 = _schedule(_fahrzeugumlauf([(1, "16.06.2025", "106/2")], {1: [11, 12]}))
+        file_204 = _schedule(_fahrzeugumlauf([(1, "16.06.2025", "106/2")], {1: [21]}))
+        create_trips_and_vehicle_schedules(file_106, prototypes, 1, session, registry)
+        create_trips_and_vehicle_schedules(file_204, prototypes, 1, session, registry)
+
+        rotations = [obj for obj in session.added if isinstance(obj, eflips.model.Rotation)]
+        assert len(rotations) == 1
+        assert rotations[0].name == "106/2"
+        attached_to = {proto.calls[0][0] for proto in prototypes.values()}
+        assert attached_to == {rotations[0]}
+        entry = registry.get(((1, date(2025, 6, 16)),))
+        assert entry is not None and entry.materialized_fahrt_ids == {11, 12, 21}
+
+    def test_multi_umlauf_working_keeps_one_rotation_and_name(self, fake_vehicle_types) -> None:
+        # A day+night working ('163/6 N63/9') grouped into one Fahrzeugumlauf, seen in two files.
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype(), 21: _FakePrototype()}
+        group = [(1, "16.06.2025", "163/6"), (2, "17.06.2025", "N63/9")]
+
+        create_trips_and_vehicle_schedules(
+            _schedule(_fahrzeugumlauf(group, {1: [11]})), prototypes, 1, session, registry
+        )
+        create_trips_and_vehicle_schedules(
+            _schedule(_fahrzeugumlauf(group, {2: [21]})), prototypes, 1, session, registry
+        )
+
+        rotations = [obj for obj in session.added if isinstance(obj, eflips.model.Rotation)]
+        assert len(rotations) == 1
+        assert rotations[0].name == "163/6 N63/9"
+
+    def test_duplicate_fahrt_across_files_raises(self, fake_vehicle_types) -> None:
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype()}
+        fu = [(1, "16.06.2025", "106/2")]
+
+        create_trips_and_vehicle_schedules(_schedule(_fahrzeugumlauf(fu, {1: [11]})), prototypes, 1, session, registry)
+        with pytest.raises(ValueError, match="materialised by more than one input file"):
+            create_trips_and_vehicle_schedules(
+                _schedule(_fahrzeugumlauf(fu, {1: [11]})), prototypes, 1, session, registry
+            )
+
+    def test_name_contradiction_raises(self, fake_vehicle_types) -> None:
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype(), 21: _FakePrototype()}
+
+        create_trips_and_vehicle_schedules(
+            _schedule(_fahrzeugumlauf([(1, "16.06.2025", "106/2")], {1: [11]})), prototypes, 1, session, registry
+        )
+        with pytest.raises(ValueError, match="is named"):
+            create_trips_and_vehicle_schedules(
+                _schedule(_fahrzeugumlauf([(1, "16.06.2025", "204/8")], {1: [21]})), prototypes, 1, session, registry
+            )
+
+    def test_vehicle_type_contradiction_raises(self, fake_vehicle_types) -> None:
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype(), 21: _FakePrototype()}
+        fu = [(1, "16.06.2025", "106/2")]
+
+        create_trips_and_vehicle_schedules(
+            _schedule(_fahrzeugumlauf(fu, {1: [11]}, fahrzeugtyp="GEG")), prototypes, 1, session, registry
+        )
+        with pytest.raises(ValueError, match="vehicle type"):
+            create_trips_and_vehicle_schedules(
+                _schedule(_fahrzeugumlauf(fu, {1: [21]}, fahrzeugtyp="EED")), prototypes, 1, session, registry
+            )
+
+    def test_betriebshof_contradiction_raises(self, fake_vehicle_types) -> None:
+        session = _FakeSession()
+        registry = RotationRegistry()
+        prototypes = {11: _FakePrototype(), 21: _FakePrototype()}
+        fu = [(1, "16.06.2025", "106/2")]
+
+        create_trips_and_vehicle_schedules(
+            _schedule(_fahrzeugumlauf(fu, {1: [11]}, betriebshof=9424)), prototypes, 1, session, registry
+        )
+        with pytest.raises(ValueError, match="Betriebshof"):
+            create_trips_and_vehicle_schedules(
+                _schedule(_fahrzeugumlauf(fu, {1: [21]}, betriebshof=9430)), prototypes, 1, session, registry
+            )
+
+
+def _rotation_fake(name: str, start_station: str, end_station: str, n_trips: int = 2) -> SimpleNamespace:
+    base = datetime(2025, 6, 16, 8, 0)
+    trips = []
+    for i in range(n_trips):
+        dep_station = start_station if i == 0 else "Mid"
+        arr_station = end_station if i == n_trips - 1 else "Mid"
+        trips.append(
+            SimpleNamespace(
+                route=SimpleNamespace(
+                    departure_station=SimpleNamespace(name=dep_station),
+                    arrival_station=SimpleNamespace(name=arr_station),
+                ),
+                departure_time=base + timedelta(hours=i),
+                arrival_time=base + timedelta(hours=i, minutes=30),
+                stop_times=[SimpleNamespace()],
+            )
+        )
+    return SimpleNamespace(name=name, id=1, trips=trips)
+
+
+class TestDeleteIncompleteRotations:
+    def test_depot_to_depot_kept(self) -> None:
+        rotation = _rotation_fake("100/1", "Betriebshof Cicerostr. Einsetzen", "Betriebshof Cicerostr. Aussetzen")
+        session = _FakeSession(rotations=[rotation])
+        delete_incomplete_rotations(1, session)
+        assert session.deleted == []
+
+    def test_cross_depot_working_kept(self) -> None:
+        # Real workings park overnight on a satellite Abstellflaeche: the endpoints are both
+        # depots but NOT the same station. These must survive.
+        rotation = _rotation_fake("194/21", "Betriebshof Lichtenberg Einsetzen", "Kaulsdorf Abstellfläche Aussetzen")
+        session = _FakeSession(rotations=[rotation])
+        delete_incomplete_rotations(1, session)
+        assert session.deleted == []
+
+    def test_window_edge_fragment_deleted_with_trips(self) -> None:
+        rotation = _rotation_fake("N02/71", "S+U Hauptbahnhof", "Betriebshof Indira-Gandhi-Str. Aussetzen")
+        session = _FakeSession(rotations=[rotation])
+        delete_incomplete_rotations(1, session)
+        assert rotation in session.deleted
+        for trip in rotation.trips:
+            assert trip in session.deleted
+            for stop_time in trip.stop_times:
+                assert stop_time in session.deleted
+
+    def test_rotation_without_trips_deleted(self) -> None:
+        rotation = SimpleNamespace(name="ghost", id=2, trips=[])
+        session = _FakeSession(rotations=[rotation])
+        delete_incomplete_rotations(1, session)
+        assert session.deleted == [rotation]

--- a/tests/test_vdv_unit.py
+++ b/tests/test_vdv_unit.py
@@ -1263,7 +1263,7 @@ class TestChainRotationFragments:
             "VT",
             [
                 _FakeTrip("SB", "SC", 9.49, 13.0),  # first by departure, hidden late arrival
-                _FakeTrip("SB", "SC", 9.5, 10.0),   # last by departure -> fragment end = SC/10:00
+                _FakeTrip("SB", "SC", 9.5, 10.0),  # last by departure -> fragment end = SC/10:00
             ],
         )
         c = _FakeRotation("C", "VT", [_FakeTrip("SC", "SD", 10.5, 11.0)])
@@ -1279,11 +1279,11 @@ class TestChainRotationFragments:
             debug=_DebugSink(),
         )
 
-        assert a.name == "A + B"          # A->B was fine
-        assert c.name == "C + D"          # C->D survived despite B->C being rejected
-        assert b in session.deleted       # B was merged into A
-        assert d in session.deleted       # D was merged into C
-        assert c not in session.deleted   # C is a chain head, not consumed
+        assert a.name == "A + B"  # A->B was fine
+        assert c.name == "C + D"  # C->D survived despite B->C being rejected
+        assert b in session.deleted  # B was merged into A
+        assert d in session.deleted  # D was merged into C
+        assert c not in session.deleted  # C is a chain head, not consumed
 
     def test_bp_endpoint_not_treated_as_open_fragment(self) -> None:
         # A rotation closing at a BP-typed depot station must not be chained onto an unrelated

--- a/tests/test_vdv_unit.py
+++ b/tests/test_vdv_unit.py
@@ -4,6 +4,7 @@ Covers _DebugSink, validate_zip_file, parse_datatypes, check_vdv451_file_header,
 import_vdv452_table_records (all table branches + error paths), and every from_dict
 method in _xmldata.py.
 """
+
 import io
 import json
 import os
@@ -39,7 +40,6 @@ from eflips.ingest.vdv._xmldata import (
     RoutenArt,
     SelFztFeld,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1011,3 +1011,297 @@ class TestFromDictMethods:
         assert obj.fzg_laenge is None
         assert obj.fzg_hoehe is None
         assert obj.fzg_breite is None
+
+
+# ---------------------------------------------------------------------------
+# Rotation fragment chaining (match_rotation_fragments)
+# ---------------------------------------------------------------------------
+
+from eflips.ingest.vdv._ingester import (
+    RotationFragment,
+    chain_rotation_fragments,
+    match_rotation_fragments,
+)
+
+
+def _fragment(
+    key,
+    start="DEPOT",
+    end="DEPOT",
+    start_h=4.0,
+    end_h=23.0,
+    start_at_depot=None,
+    end_at_depot=None,
+    vehicle_type="VT1",
+    home_depot=9408,
+    day=0,
+):
+    """Build a RotationFragment with terse test notation; hours are offsets from an arbitrary epoch."""
+    base = datetime(2023, 3, 27, 0, 0) + timedelta(days=day)
+    return RotationFragment(
+        key=key if isinstance(key, tuple) else (key,),
+        start_station=start,
+        start_time=base + timedelta(hours=start_h),
+        end_station=end,
+        end_time=base + timedelta(hours=end_h),
+        start_at_depot=start == "DEPOT" if start_at_depot is None else start_at_depot,
+        end_at_depot=end == "DEPOT" if end_at_depot is None else end_at_depot,
+        vehicle_type=vehicle_type,
+        home_depot=home_depot,
+    )
+
+
+class TestMatchRotationFragments:
+    def test_no_fragments(self) -> None:
+        assert match_rotation_fragments([]) == []
+
+    def test_closed_rotations_ignored(self) -> None:
+        frags = [
+            _fragment("a", start="DEPOT", end="DEPOT"),
+            _fragment("b", start="DEPOT", end="DEPOT", start_h=5, end_h=22),
+        ]
+        assert match_rotation_fragments(frags) == []
+
+    def test_simple_handover(self) -> None:
+        # a: depot -> stop X at 21:00; b: stop X 21:30 -> depot.
+        a = _fragment("a", end="X", end_h=21.0)
+        b = _fragment("b", start="X", start_h=21.5)
+        assert match_rotation_fragments([a, b]) == [(("a",), ("b",))]
+
+    def test_negative_gap_rejected(self) -> None:
+        a = _fragment("a", end="X", end_h=22.0)
+        b = _fragment("b", start="X", start_h=21.5)  # departs before a arrives
+        assert match_rotation_fragments([a, b]) == []
+
+    def test_gap_above_max_rejected_at_max_accepted(self) -> None:
+        a = _fragment("a", end="X", end_h=1.0)
+        b = _fragment("b", start="X", start_h=7.0, day=1)  # 30 h later exactly
+        c = _fragment("c", start="X", start_h=7.0001, day=1)
+        assert match_rotation_fragments([a, b]) == [(("a",), ("b",))]
+        assert match_rotation_fragments([a, c]) == []
+
+    def test_vehicle_type_is_hard_constraint(self) -> None:
+        # The N20 pattern: the tempting 3-minute pairing has the wrong vehicle type; the correct
+        # partner is hours away. The type constraint must override the smaller gap.
+        n20_74 = _fragment("N20/74", end="Hainbuchenstr.", end_h=3.8, vehicle_type="1022")
+        n20_72 = _fragment("N20/72", start="Hainbuchenstr.", start_h=3.85, vehicle_type="1013")
+        line_220_10 = _fragment("220/10", start="Hainbuchenstr.", start_h=5.0, vehicle_type="1022")
+        n20_51 = _fragment("N20/51", end="Hainbuchenstr.", end_h=2.25, vehicle_type="1013")
+        pairs = match_rotation_fragments([n20_74, n20_72, line_220_10, n20_51])
+        assert (("N20/74",), ("220/10",)) in pairs
+        assert (("N20/51",), ("N20/72",)) in pairs
+        assert len(pairs) == 2
+
+    def test_home_depot_is_hard_constraint(self) -> None:
+        a = _fragment("a", end="X", end_h=21.0, home_depot=9408)
+        b = _fragment("b", start="X", start_h=21.5, home_depot=39420)
+        assert match_rotation_fragments([a, b]) == []
+
+    def test_missing_home_depot_is_wildcard(self) -> None:
+        a = _fragment("a", end="X", end_h=21.0, home_depot=None)
+        b = _fragment("b", start="X", start_h=21.5, home_depot=39420)
+        assert match_rotation_fragments([a, b]) == [(("a",), ("b",))]
+
+    def test_one_to_one_smallest_gap_first(self) -> None:
+        # Two buses parked at X, two departures: earliest departure takes the latest arrival
+        # (smallest gap), the remaining pair still matches 1:1.
+        p1 = _fragment("p1", end="X", end_h=20.0)
+        p2 = _fragment("p2", end="X", end_h=21.0)
+        s1 = _fragment("s1", start="X", start_h=21.5)
+        s2 = _fragment("s2", start="X", start_h=23.0)
+        pairs = match_rotation_fragments([p1, p2, s1, s2])
+        assert (("p2",), ("s1",)) in pairs
+        assert (("p1",), ("s2",)) in pairs
+        assert len(pairs) == 2
+
+    def test_deterministic_tie_break_on_equal_gap(self) -> None:
+        # Two interchangeable predecessors arrive at the same time: the smaller key wins, always.
+        p_b = _fragment("b", end="X", end_h=21.0)
+        p_a = _fragment("a", end="X", end_h=21.0)
+        s = _fragment("s", start="X", start_h=22.0)
+        for frags in ([p_b, p_a, s], [p_a, p_b, s], [s, p_b, p_a]):
+            assert match_rotation_fragments(frags) == [(("a",), ("s",))]
+
+    def test_transitive_chain(self) -> None:
+        # depot -> X -> Y -> depot over three fragments.
+        a = _fragment("a", end="X", end_h=10.0)
+        b = _fragment("b", start="X", end="Y", start_h=11.0, end_h=15.0)
+        c = _fragment("c", start="Y", start_h=16.0)
+        pairs = match_rotation_fragments([a, b, c])
+        assert (("a",), ("b",)) in pairs
+        assert (("b",), ("c",)) in pairs
+        assert len(pairs) == 2
+
+    def test_cross_day_chain(self) -> None:
+        # Night bus left at the terminal at 02:15, fetched at 03:21 the next service day.
+        p = _fragment("N20/51", end="Hainbuchenstr.", end_h=26.25, vehicle_type="1013")
+        s = _fragment("N20/71", start="Hainbuchenstr.", start_h=3.35, day=1, vehicle_type="1013")
+        assert match_rotation_fragments([p, s]) == [(("N20/51",), ("N20/71",))]
+
+    def test_fragment_never_chains_to_itself(self) -> None:
+        # A street->street fragment could otherwise "follow itself" at gap 0 if start == end.
+        f = _fragment("f", start="X", end="X", start_h=4.0, end_h=4.0)
+        assert match_rotation_fragments([f]) == []
+
+
+class TestRecUmlaufBhof:
+    def _base(self) -> dict:
+        return {
+            "BASIS_VERSION": 369,
+            "TAGESART_NR": 1,
+            "UM_UID": 200,
+            "ANF_ORT": 300,
+            "ANF_ONR_TYP": 1,
+            "END_ORT": 301,
+            "END_ONR_TYP": 1,
+        }
+
+    def test_bhof_ort_nr_parsed(self) -> None:
+        obj = RecUmlauf.from_dict({**self._base(), "BHOF_ORT_NR": 9408})
+        assert obj.bhof_ort_nr == 9408
+
+    def test_bhof_ort_nr_missing_gives_none(self) -> None:
+        obj = RecUmlauf.from_dict(self._base())
+        assert obj.bhof_ort_nr is None
+
+    def test_bhof_ort_nr_zero_gives_none(self) -> None:
+        obj = RecUmlauf.from_dict({**self._base(), "BHOF_ORT_NR": 0})
+        assert obj.bhof_ort_nr is None
+
+
+# ---------------------------------------------------------------------------
+# Rotation fragment chaining (chain_rotation_fragments)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRoute:
+    def __init__(self, departure_station: object, arrival_station: object) -> None:
+        self.departure_station = departure_station
+        self.arrival_station = arrival_station
+
+
+class _FakeTrip:
+    """Trip whose ``rotation`` setter mirrors SQLAlchemy's backref: reassigning it moves the
+    trip out of the old rotation's ``trips`` and into the new one's, exactly as the ORM does
+    when ``chain_rotation_fragments`` reparents trips onto the chain head."""
+
+    def __init__(self, dep_station, arr_station, dep_h: float, arr_h: float) -> None:
+        base = datetime(2024, 1, 1, 0, 0)
+        self.route = _FakeRoute(dep_station, arr_station)
+        self.departure_time = base + timedelta(hours=dep_h)
+        self.arrival_time = base + timedelta(hours=arr_h)
+        self._rotation: "_FakeRotation | None" = None
+
+    @property
+    def rotation(self) -> "_FakeRotation | None":
+        return self._rotation
+
+    @rotation.setter
+    def rotation(self, new: "_FakeRotation | None") -> None:
+        if self._rotation is not None and self in self._rotation.trips:
+            self._rotation.trips.remove(self)
+        self._rotation = new
+        if new is not None and self not in new.trips:
+            new.trips.append(self)
+
+
+class _FakeRotation:
+    def __init__(self, name: str, vehicle_type: object, trips: "list[_FakeTrip]") -> None:
+        self.name = name
+        self.vehicle_type = vehicle_type
+        self.trips: "list[_FakeTrip]" = []
+        for trip in trips:
+            trip.rotation = self
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.deleted: list = []
+
+    def delete(self, obj: object) -> None:
+        self.deleted.append(obj)
+
+    def flush(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class TestChainRotationFragments:
+    """Integration-ish coverage for the merge/reparent/delete logic, using plain in-memory
+    fakes instead of an ORM session (the full-DB ``test_ingest`` is skipped for runtime)."""
+
+    def _key(self, name: str) -> tuple:
+        # (basis_version, tagesart_nr, um_uid, date) — the shape chain_rotation_fragments expects.
+        return (1, 1, name, date(2024, 1, 1))
+
+    def test_linear_chain_merges_all(self) -> None:
+        # A(->SB) | B(SB->SC) | C(SC->SD): a plain three-fragment working, all links valid.
+        a = _FakeRotation("A", "VT", [_FakeTrip("SA", "SB", 8.0, 9.0)])
+        b = _FakeRotation("B", "VT", [_FakeTrip("SB", "SC", 9.5, 10.0)])
+        c = _FakeRotation("C", "VT", [_FakeTrip("SC", "SD", 10.5, 11.0)])
+        rotations = {self._key(n): r for n, r in (("A", a), ("B", b), ("C", c))}
+
+        session = _FakeSession()
+        chain_rotation_fragments(
+            session,
+            rotations,
+            home_depot_by_rotation_pk={},
+            depot_stations=set(),
+            debug=_DebugSink(),
+        )
+
+        assert a.name == "A + B + C"
+        assert session.deleted == [b, c]
+
+    def test_safety_net_requeues_downstream_link(self) -> None:
+        # Chain A->B->C->D as seen by the matcher, but B hides a late-arriving trip so the head's
+        # true last arrival (13:00) sits after C's departure (10:30). The safety net must reject
+        # B->C, yet C->D is an independently valid link and must still be built. Regression guard
+        # for the bug where the aborted successor was never re-processed as its own chain root.
+        a = _FakeRotation("A", "VT", [_FakeTrip("SA", "SB", 8.0, 9.0)])
+        b = _FakeRotation(
+            "B",
+            "VT",
+            [
+                _FakeTrip("SB", "SC", 9.49, 13.0),  # first by departure, hidden late arrival
+                _FakeTrip("SB", "SC", 9.5, 10.0),   # last by departure -> fragment end = SC/10:00
+            ],
+        )
+        c = _FakeRotation("C", "VT", [_FakeTrip("SC", "SD", 10.5, 11.0)])
+        d = _FakeRotation("D", "VT", [_FakeTrip("SD", "SE", 11.5, 12.0)])
+        rotations = {self._key(n): r for n, r in (("A", a), ("B", b), ("C", c), ("D", d))}
+
+        session = _FakeSession()
+        chain_rotation_fragments(
+            session,
+            rotations,
+            home_depot_by_rotation_pk={},
+            depot_stations=set(),
+            debug=_DebugSink(),
+        )
+
+        assert a.name == "A + B"          # A->B was fine
+        assert c.name == "C + D"          # C->D survived despite B->C being rejected
+        assert b in session.deleted       # B was merged into A
+        assert d in session.deleted       # D was merged into C
+        assert c not in session.deleted   # C is a chain head, not consumed
+
+    def test_bp_endpoint_not_treated_as_open_fragment(self) -> None:
+        # A rotation closing at a BP-typed depot station must not be chained onto an unrelated
+        # working that shares that station. With BP in depot_stations, both endpoints are closed,
+        # so the matcher never pairs them and nothing is merged/deleted.
+        closed = _FakeRotation("CLOSED", "VT", [_FakeTrip("BP", "BP", 8.0, 9.0)])
+        other = _FakeRotation("OTHER", "VT", [_FakeTrip("BP", "BP", 9.5, 10.5)])
+        rotations = {self._key(n): r for n, r in (("CLOSED", closed), ("OTHER", other))}
+
+        session = _FakeSession()
+        chain_rotation_fragments(
+            session,
+            rotations,
+            home_depot_by_rotation_pk={},
+            depot_stations={"BP"},
+            debug=_DebugSink(),
+        )
+
+        assert closed.name == "CLOSED"
+        assert other.name == "OTHER"
+        assert session.deleted == []


### PR DESCRIPTION
This PR updates the handling of BVGXML partial rotations, as they could have been created when different BVGXML input files contain different fragments of the same rotation split over different files.

I assumed it was the same failure as VDV, with rotations being cut-off at the edge of the time, but apparently it's much more about the preious `merge_identical_rotations()` treating fragment sincorrectly, indexing by name, which is not actually unique.