### PR TITLE
Estimate zero-distance depot legs instead of a sentine

### DIFF
--- a/eflips/ingest/bvgxml/_ingester.py
+++ b/eflips/ingest/bvgxml/_ingester.py
@@ -12,15 +12,12 @@ from zipfile import BadZipFile, ZipFile
 
 import eflips.model
 from eflips.model import ConsistencyWarning, create_engine
-from geoalchemy2.functions import ST_Distance
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from eflips.ingest.base import AbstractIngester
 from eflips.ingest.bvgxml._pipeline import (
     RotationRegistry,
     TimeProfile,
-    ZERO_DISTANCE_SENTINEL_M,
     create_routes_and_time_profiles,
     create_stations,
     create_trip_prototypes,
@@ -206,23 +203,9 @@ class BvgxmlIngester(AbstractIngester):
             session.expire_all()
             report(6)
 
-            long_route_q = (
-                session.query(eflips.model.Route)
-                .filter(eflips.model.Route.scenario_id == scenario_id)
-                .filter(eflips.model.Route.distance >= ZERO_DISTANCE_SENTINEL_M)
-            )
-            for route in long_route_q:
-                first_point = route.departure_station.geom
-                last_point = route.arrival_station.geom
-                first_point_soldner = func.ST_Transform(first_point, 3068)
-                last_point_soldner = func.ST_Transform(last_point, 3068)
-                dist = session.query(ST_Distance(first_point_soldner, last_point_soldner)).one()[0]
-                with session.no_autoflush:
-                    route.distance = dist
-                    route.assoc_route_stations[-1].elapsed_distance = dist
-                route.name = "CHECK DISTANCE: " + route.name
-            session.flush()
-            session.expire_all()
+            # Phase 7 used to rewrite sentinel-marked zero-distance routes here; the
+            # pipeline now estimates those distances directly, so the phase is a no-op
+            # kept only to preserve the progress-bar numbering.
             report(7)
 
             merge_identical_stations(scenario_id, session)

--- a/eflips/ingest/bvgxml/_pipeline.py
+++ b/eflips/ingest/bvgxml/_pipeline.py
@@ -46,6 +46,7 @@ deployment surfaces a new edge case:
   to a single station.
 """
 import logging
+import math
 import os
 import sqlite3
 import statistics
@@ -646,6 +647,7 @@ def create_routes_and_time_profiles(
         # This way, we are sure the departure and arrival stations match as well as the total distance
         assocs: List[eflips.model.AssocRouteStation] = []
         elapsed_distance = 0.0
+        distance_is_estimated = False
 
         time_profile_points: Dict[
             int, List[TimeProfile.TimeProfilePoint]
@@ -683,11 +685,25 @@ def create_routes_and_time_profiles(
                 elapsed_distance += segment.streckenlaenge
 
             # SPECIAL FIXES
-            # Some routes have a distance of zero even once the last point is reached
+            # Some routes have a distance of zero even once the last point is reached, because the export
+            # carries no Streckenlänge for the depot connection anywhere. Estimate the distance as
+            # crow-fly × detour factor from the grid-point coordinates (Soldner, in millimeters).
             if i == len(route.punktfolge.punkt) - 1 and elapsed_distance == 0:
-                # We mark these by putting an obscenely large number in the distance
-                logger.warning(f"Route {route.lfd_nr} of line {db_line.name} has a zero distance at the end.")
-                elapsed_distance += ZERO_DISTANCE_SENTINEL_M
+                first_gp = grid_points[route.punktfolge.punkt[0].netzpunkt]
+                last_gp = grid_points[route.punktfolge.punkt[-1].netzpunkt]
+                crow_fly_m = (
+                    math.hypot(
+                        first_gp.xkoordinate - last_gp.xkoordinate,
+                        first_gp.ykoordinate - last_gp.ykoordinate,
+                    )
+                    / 1000.0
+                )
+                elapsed_distance = max(CROW_FLY_DETOUR_FACTOR * crow_fly_m, MIN_ESTIMATED_DISTANCE_M)
+                distance_is_estimated = True
+                logger.warning(
+                    f"Route {route.lfd_nr} of line {db_line.name} has a zero distance at the end. "
+                    f"Estimating {elapsed_distance:.0f} m from the crow-fly distance."
+                )
 
             # Some time profiles have a zero time at the end
             if i == len(route.punktfolge.punkt) - 1:
@@ -698,13 +714,9 @@ def create_routes_and_time_profiles(
                         )
 
                         SPEED = 30 / 3.6  # 30 km/h in m/s
-                        if elapsed_distance != 0:
-                            duration = elapsed_distance / SPEED
-                        else:
-                            logger.warning(
-                                f"Route {route.lfd_nr} of line {db_line.name} has a zero distance at the end. Calculating duration with a fixed speed of 30 km/h and a distance of 1 km."
-                            )
-                            duration = 1000 / SPEED
+                        # elapsed_distance is always usable here: if the route also had a zero
+                        # distance, it has already been replaced by the crow-fly estimate above.
+                        duration = elapsed_distance / SPEED
 
                         # Now, depending on whether it is an EInsetzfahrt or Aussetzfahrt, we shoft the beginning forward
                         # or the end backward
@@ -871,6 +883,8 @@ def create_routes_and_time_profiles(
             first_grid_point=grid_points[route.punktfolge.punkt[0].netzpunkt],
             last_grid_point=grid_points[route.punktfolge.punkt[-1].netzpunkt],
         )
+        if distance_is_estimated:
+            db_route.name = "CHECK DISTANCE: " + db_route.name
 
         # Now we can check if there already is a route with the same assocs.
         # We compare by station identity and elapsed_distance rounded to mm —
@@ -1438,14 +1452,18 @@ def merge_identical_stations(scenario_id: int, session: Session) -> None:
 DEPOT_NAME_TOKENS: Tuple[str, ...] = ("Betriebshof", "Abstellfläche")
 
 
-# Sentinel applied to ``Route.distance`` when ``create_routes_and_time_profiles``
-# encounters a Punktfolge that walked back to its own start (cumulative
-# Streckenlänge of 0). The post-processing step in :class:`BvgxmlIngester`
-# rewrites these distances using the geometric distance between the
-# departure and arrival stations and prepends "CHECK DISTANCE:" to the route
-# name. One million kilometers is large enough that no real Berlin route
-# could ever match it, so we can use it as a query filter cleanly.
-ZERO_DISTANCE_SENTINEL_M: float = 1e6 * 1000  # one million kilometers, in meters
+# Some routes (in practice: 2-point depot pull-in/pull-out legs) have a
+# cumulative Streckenlänge of 0 because the export carries no length for the
+# depot connection anywhere. ``create_routes_and_time_profiles`` estimates the
+# distance as crow-fly × this detour factor and prepends "CHECK DISTANCE:" to
+# the route name. The factor was validated against point pairs in the Berlin
+# 2025-06 export where other time profiles carry real driving times
+# (crow-fly × 1.4 at 30 km/h reproduces them to within ~±30 %).
+CROW_FLY_DETOUR_FACTOR: float = 1.4
+
+# Floor for the estimated distance, used when even the crow-fly distance is
+# zero (departure and arrival grid points are co-located).
+MIN_ESTIMATED_DISTANCE_M: float = 1000.0
 
 
 # Station-merge overrides for sibling stations whose short names don't share a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-ingest"
-version = "2.1.0"
+version = "2.1.1"
 description = "A collection of import scripts for converting bus schedule data into the [eflips-model](https://github.com/mpm-tu-berlin/eflips-model) data format."
 authors = [
     "Ludger Heide <ludger.heide@lhtechnologies.de>"

--- a/tests/test_bvgxml.py
+++ b/tests/test_bvgxml.py
@@ -1,5 +1,7 @@
 import glob
+import math
 import os
+from datetime import timedelta
 from pathlib import Path
 from typing import List, Dict
 from uuid import UUID, uuid4
@@ -12,6 +14,8 @@ from sqlalchemy.orm import Session
 
 from eflips.ingest.bvgxml import BvgxmlIngester
 from eflips.ingest.bvgxml._pipeline import (
+    CROW_FLY_DETOUR_FACTOR,
+    MIN_ESTIMATED_DISTANCE_M,
     load_and_validate_xml,
     create_stations,
     setup_working_dictionaries,
@@ -122,6 +126,75 @@ class TestBVGXML:
                 for assoc in route.assoc_route_stations:
                     assert assoc.station is not None
                     assert assoc.location is not None
+
+    def test_zero_distance_zero_time_route_is_estimated(self, linienfahrplan):
+        """
+        Regression test: depot pull-in/pull-out legs whose Streckenlänge AND driving times are
+        all zero in the export used to receive a 1e9 m sentinel distance, which the zero-time
+        fallback then turned into a ~3.8 year duration. Both values must now be estimated from
+        the crow-fly distance between the first and last grid point.
+        """
+        engine = create_engine(os.environ["DATABASE_URL"])
+        eflips.model.Base.metadata.drop_all(engine)
+        eflips.model.setup_database(engine)
+
+        # Strip both the segment lengths and the driving times from one Einsetzfahrt (lfd_nr 1,
+        # EPkt → BPunkt) and one Aussetzfahrt (lfd_nr 2, BPunkt → APkt), mirroring the broken
+        # depot legs observed in real exports.
+        strecken = {s.id: s for s in linienfahrplan.streckennetz_daten.strecken.strecke}
+        grid_points = {gp.nummer: gp for gp in linienfahrplan.streckennetz_daten.netzpunkte.netzpunkt}
+        routes = {r.lfd_nr: r for r in linienfahrplan.linien_daten.linie.routen_daten.route}
+        expected_distances: Dict[int, float] = {}
+        for lfd_nr in (1, 2):
+            route = routes[lfd_nr]
+            for strecke in route.streckenfolge.strecke:
+                strecken[strecke.strecken_id].streckenlaenge = 0
+            for fahrzeitprofil in route.fahrzeitprofile.fahrzeitprofil:
+                for punkt in fahrzeitprofil.fahrzeitprofilpunkte.punkt:
+                    punkt.streckenfahrzeit = 0
+            first_gp = grid_points[route.punktfolge.punkt[0].netzpunkt]
+            last_gp = grid_points[route.punktfolge.punkt[-1].netzpunkt]
+            crow_fly_m = (
+                math.hypot(
+                    first_gp.xkoordinate - last_gp.xkoordinate,
+                    first_gp.ykoordinate - last_gp.ykoordinate,
+                )
+                / 1000.0
+            )
+            expected_distances[lfd_nr] = max(CROW_FLY_DETOUR_FACTOR * crow_fly_m, MIN_ESTIMATED_DISTANCE_M)
+
+        with Session(engine) as session:
+            scenario = eflips.model.Scenario(
+                name="Test Scenario",
+            )
+            session.add(scenario)
+            session.flush()
+            scenario_id = scenario.id
+
+            station_mapping: dict[int, eflips.model.Station] = {}
+            create_stations(linienfahrplan, scenario_id, session, station_mapping)
+            trip_time_profiles, db_routes_by_lfd_nr = create_routes_and_time_profiles(
+                linienfahrplan, scenario_id, session, station_mapping
+            )
+
+            SPEED = 30 / 3.6  # 30 km/h in m/s
+            for lfd_nr in (1, 2):
+                db_route = db_routes_by_lfd_nr[lfd_nr]
+                assert db_route is not None
+                assert db_route.distance == pytest.approx(expected_distances[lfd_nr])
+                assert db_route.name.startswith("CHECK DISTANCE: ")
+
+                expected_duration = timedelta(seconds=expected_distances[lfd_nr] / SPEED)
+                assert expected_duration < timedelta(hours=2)
+                for points in trip_time_profiles[lfd_nr].values():
+                    if lfd_nr == 1:
+                        # Einsetzfahrt: the start is shifted back by the estimated duration
+                        offset = points[0].arrival_offset_from_start
+                        assert offset.total_seconds() == pytest.approx(-expected_duration.total_seconds())
+                    else:
+                        # Aussetzfahrt: the end is extended by the estimated duration
+                        offset = points[-1].arrival_offset_from_start
+                        assert offset.total_seconds() == pytest.approx(expected_duration.total_seconds())
 
     def test_create_trip_prototypes(self, linienfahrplan):
         engine = create_engine(os.environ["DATABASE_URL"])


### PR DESCRIPTION
l that corrupted durations

BVGXML routes whose cumulative Streckenlänge is zero (depot pull-in/ pull-out legs whose lengths are missing everywhere in the export) used to get a 1e9 m sentinel distance for later replacement. The adjacent zero-time fallback did not know about the sentinel and computed 1e9 m / 30 km/h ≈ 3.8 years as the trip duration, shifting one trip per affected rotation by years and blowing up downstream simulations sized on the min/max trip timestamps.

Replace the sentinel with a direct estimate at route-creation time: crow-fly distance between the first and last grid point (Soldner coordinates, planar) times a detour factor of 1.4, floored at 1 km for co-located points. The factor reproduces the known driving times of the same point pairs in the Berlin 2025-06 export to within ~±30 %. The zero-time fallback now divides a real distance by 30 km/h, and the post-ingest sentinel rewrite in BvgxmlIngester is gone; the "CHECK DISTANCE: " route-name marker is kept.